### PR TITLE
feat: add seasonal calendar + editable homepage intro, restructure admin

### DIFF
--- a/.claude/context.md
+++ b/.claude/context.md
@@ -157,6 +157,12 @@ Cloudflare-Tunnel, Backup-Strategie, Logs/Monitoring. Berücksichtige ARM64.
 **DB-Queries / Schema** — Postgres 16, SQLAlchemy ORM. Bei `ALTER TABLE` o.ä. → immer
 über Alembic-Migration. Vor Migrations Backup-Erinnerung.
 
+**Konfigurierbare Texte / Site-Settings** — Editierbare Texte (z.B. Homepage-Intro)
+liegen in der Tabelle `site_settings` (Key/Value, Plain-Text). Für neue editierbare
+Felder: Key zur `ALLOWED_KEYS`-Whitelist in `backend/routers/settings.py` ergänzen,
+im Frontend `getSetting('<key>')` aus `api/settings.ts` mit Fallback verwenden,
+Admin-UI in `pages/AdminSettings.tsx` erweitern.
+
 **Security-Hardening** — Rate Limiting, JWT-Lifetime, Bcrypt-Rounds, Upload-Validation,
 CORS, Cloudflare-Konfig, Container-Hardening (read-only FS wo möglich, etc.).
 
@@ -170,6 +176,10 @@ CORS, Cloudflare-Konfig, Container-Hardening (read-only FS wo möglich, etc.).
 - Keine Dependency-Major-Bumps "nebenbei" — die laufen über Dependabot-PRs
 - Bei Änderungen, die Migration brauchen, niemals direkt `models.py` editieren ohne
   Alembic-Schritt mitzunennen
+- **CORS allow_methods**: Backend erlaubt nur `GET, POST, PATCH, DELETE, OPTIONS`
+  (siehe `backend/main.py`). Niemals `PUT` für neue Endpoints — Update-Konvention im
+  Repo ist **PATCH** (siehe `routers/tags.py`, `routers/settings.py`). Wenn `PUT`
+  wirklich nötig wird, muss `allow_methods` erweitert werden.
 - Bei Schema-Änderungen IMMER vorher prüfen ob die Migration auch auf einer frischen
   DB läuft (E2E-Tests bauen DB von 0 auf). Lokal gegen einen Wegwerf-Postgres testen
   bevor pushen. Eine Migration die auf Prod funktioniert weil bestehende Tabellen da
@@ -178,8 +188,9 @@ CORS, Cloudflare-Konfig, Container-Hardening (read-only FS wo möglich, etc.).
 ## Aktuelle Aufgabe
 
 <!-- HIER pro Chat ausfüllen: -->
-**Branch**: `main`
-**Was ich machen will**: …
+**Branch**: 
+**Was ich machen will**: 
+
 
 ## Am Ende dieses Chats
 

--- a/backend/alembic/versions/a4c5274d72e4_add_site_settings_table.py
+++ b/backend/alembic/versions/a4c5274d72e4_add_site_settings_table.py
@@ -1,0 +1,57 @@
+"""add site_settings table
+
+Revision ID: a4c5274d72e4
+Revises: e511624ef4ca
+Create Date: 2026-04-27 15:43:49.125516
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'a4c5274d72e4'
+down_revision: Union[str, Sequence[str], None] = 'e511624ef4ca'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        'site_settings',
+        sa.Column('key', sa.String(), nullable=False),
+        sa.Column('value', sa.Text(), nullable=False, server_default=''),
+        sa.Column(
+            'updated_at',
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint('key'),
+    )
+    op.create_index(
+        op.f('ix_site_settings_key'),
+        'site_settings',
+        ['key'],
+        unique=False,
+    )
+
+    # Seed: aktueller Homepage-Intro-Text
+    op.execute(
+        sa.text(
+            "INSERT INTO site_settings (key, value) "
+            "VALUES (:key, :value)"
+        ).bindparams(
+            key='homepage_intro',
+            value='Hier teile ich meine Gedanken, Rezepte und Ideen. Schön dass du da bist!',
+        )
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index(op.f('ix_site_settings_key'), table_name='site_settings')
+    op.drop_table('site_settings')

--- a/backend/alembic/versions/e511624ef4ca_add_seasonal_items.py
+++ b/backend/alembic/versions/e511624ef4ca_add_seasonal_items.py
@@ -1,0 +1,227 @@
+"""add seasonal_items
+
+Revision ID: e511624ef4ca
+Revises: b5e06c314352
+Create Date: 2026-04-26 15:25:14.403188
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'e511624ef4ca'
+down_revision: Union[str, Sequence[str], None] = 'b5e06c314352'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+# ---------- Seed-Daten ----------
+# ~50 Sorten für Mitteleuropa (D/A), orientiert an gängigen Saisonkalendern.
+# months = Monate mit regionaler Hauptverfügbarkeit; availability gibt an,
+# ob das Item überwiegend frisch regional, aus Lager oder per Import angeboten wird.
+
+SEED_ITEMS = [
+    # ----- Obst -----
+    {"name": "Apfel", "category": "fruit", "months": [8, 9, 10, 11, 12, 1, 2, 3, 4],
+     "availability": "storage", "notes": "Heimisches Kernobst, ganzjährig aus Lager"},
+    {"name": "Birne", "category": "fruit", "months": [8, 9, 10, 11, 12, 1, 2],
+     "availability": "storage", "notes": "Hauptsaison Spätsommer/Herbst"},
+    {"name": "Erdbeere", "category": "fruit", "months": [5, 6, 7],
+     "availability": "regional", "notes": "Kurze Hauptsaison Mai bis Juli"},
+    {"name": "Himbeere", "category": "fruit", "months": [6, 7, 8, 9],
+     "availability": "regional", "notes": None},
+    {"name": "Brombeere", "category": "fruit", "months": [7, 8, 9],
+     "availability": "regional", "notes": None},
+    {"name": "Heidelbeere", "category": "fruit", "months": [7, 8, 9],
+     "availability": "regional", "notes": None},
+    {"name": "Johannisbeere", "category": "fruit", "months": [6, 7, 8],
+     "availability": "regional", "notes": None},
+    {"name": "Stachelbeere", "category": "fruit", "months": [6, 7, 8],
+     "availability": "regional", "notes": None},
+    {"name": "Kirsche", "category": "fruit", "months": [6, 7, 8],
+     "availability": "regional", "notes": "Süß- und Sauerkirschen"},
+    {"name": "Marille", "category": "fruit", "months": [6, 7, 8],
+     "availability": "regional", "notes": "Wachauer Marille als Spezialität"},
+    {"name": "Pfirsich", "category": "fruit", "months": [7, 8, 9],
+     "availability": "regional", "notes": None},
+    {"name": "Nektarine", "category": "fruit", "months": [7, 8, 9],
+     "availability": "regional", "notes": None},
+    {"name": "Pflaume", "category": "fruit", "months": [7, 8, 9, 10],
+     "availability": "regional", "notes": None},
+    {"name": "Zwetschge", "category": "fruit", "months": [8, 9, 10],
+     "availability": "regional", "notes": None},
+    {"name": "Weintraube", "category": "fruit", "months": [8, 9, 10, 11],
+     "availability": "regional", "notes": None},
+    {"name": "Rhabarber", "category": "fruit", "months": [4, 5, 6],
+     "availability": "regional", "notes": "Botanisch Gemüse, kulinarisch Obst"},
+    {"name": "Quitte", "category": "fruit", "months": [9, 10, 11],
+     "availability": "regional", "notes": None},
+    {"name": "Holunderbeere", "category": "fruit", "months": [8, 9],
+     "availability": "regional", "notes": None},
+
+    # ----- Gemüse -----
+    {"name": "Kartoffel", "category": "vegetable", "months": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+     "availability": "storage", "notes": "Frühkartoffeln ab Juni, Lager ganzjährig"},
+    {"name": "Karotte", "category": "vegetable", "months": [6, 7, 8, 9, 10, 11, 12, 1, 2, 3],
+     "availability": "storage", "notes": "Bundkarotten ab Juni, Lager bis Frühjahr"},
+    {"name": "Zwiebel", "category": "vegetable", "months": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+     "availability": "storage", "notes": "Lagerware ganzjährig"},
+    {"name": "Knoblauch", "category": "vegetable", "months": [7, 8, 9, 10, 11, 12, 1, 2],
+     "availability": "storage", "notes": None},
+    {"name": "Lauch", "category": "vegetable", "months": [1, 2, 3, 4, 9, 10, 11, 12],
+     "availability": "regional", "notes": "Winterlauch besonders aromatisch"},
+    {"name": "Rote Rübe", "category": "vegetable", "months": [6, 7, 8, 9, 10, 11, 12, 1, 2, 3],
+     "availability": "storage", "notes": "Auch Rote Bete genannt"},
+    {"name": "Sellerie", "category": "vegetable", "months": [8, 9, 10, 11, 12, 1, 2, 3],
+     "availability": "storage", "notes": "Knollen- und Stangensellerie"},
+    {"name": "Pastinake", "category": "vegetable", "months": [10, 11, 12, 1, 2, 3],
+     "availability": "storage", "notes": None},
+    {"name": "Kürbis", "category": "vegetable", "months": [8, 9, 10, 11, 12, 1],
+     "availability": "storage", "notes": "Hokkaido und Butternut sehr beliebt"},
+    {"name": "Spinat", "category": "vegetable", "months": [3, 4, 5, 9, 10, 11],
+     "availability": "regional", "notes": None},
+    {"name": "Mangold", "category": "vegetable", "months": [5, 6, 7, 8, 9, 10],
+     "availability": "regional", "notes": None},
+    {"name": "Salat", "category": "vegetable", "months": [4, 5, 6, 7, 8, 9, 10],
+     "availability": "regional", "notes": "Kopf-, Eichblatt-, Lollo etc."},
+    {"name": "Vogerlsalat", "category": "vegetable", "months": [10, 11, 12, 1, 2, 3],
+     "availability": "regional", "notes": "Auch Feldsalat"},
+    {"name": "Chicorée", "category": "vegetable", "months": [10, 11, 12, 1, 2, 3, 4],
+     "availability": "regional", "notes": None},
+    {"name": "Radicchio", "category": "vegetable", "months": [6, 7, 8, 9, 10, 11, 12],
+     "availability": "regional", "notes": None},
+    {"name": "Rucola", "category": "vegetable", "months": [4, 5, 6, 7, 8, 9, 10],
+     "availability": "regional", "notes": None},
+    {"name": "Tomate", "category": "vegetable", "months": [6, 7, 8, 9, 10],
+     "availability": "regional", "notes": "Freilandtomaten in Hauptsaison"},
+    {"name": "Gurke", "category": "vegetable", "months": [6, 7, 8, 9, 10],
+     "availability": "regional", "notes": None},
+    {"name": "Paprika", "category": "vegetable", "months": [7, 8, 9, 10],
+     "availability": "regional", "notes": None},
+    {"name": "Zucchini", "category": "vegetable", "months": [6, 7, 8, 9, 10],
+     "availability": "regional", "notes": None},
+    {"name": "Aubergine", "category": "vegetable", "months": [7, 8, 9, 10],
+     "availability": "regional", "notes": None},
+    {"name": "Brokkoli", "category": "vegetable", "months": [6, 7, 8, 9, 10],
+     "availability": "regional", "notes": None},
+    {"name": "Karfiol", "category": "vegetable", "months": [6, 7, 8, 9, 10, 11],
+     "availability": "regional", "notes": "Auch Blumenkohl"},
+    {"name": "Kohlrabi", "category": "vegetable", "months": [5, 6, 7, 8, 9, 10],
+     "availability": "regional", "notes": None},
+    {"name": "Weißkraut", "category": "vegetable", "months": [6, 7, 8, 9, 10, 11, 12, 1, 2, 3],
+     "availability": "storage", "notes": None},
+    {"name": "Rotkraut", "category": "vegetable", "months": [9, 10, 11, 12, 1, 2, 3],
+     "availability": "storage", "notes": None},
+    {"name": "Wirsing", "category": "vegetable", "months": [6, 7, 8, 9, 10, 11, 12, 1, 2, 3],
+     "availability": "storage", "notes": None},
+    {"name": "Grünkohl", "category": "vegetable", "months": [11, 12, 1, 2],
+     "availability": "regional", "notes": "Nach erstem Frost am besten"},
+    {"name": "Kohlsprossen", "category": "vegetable", "months": [10, 11, 12, 1, 2, 3],
+     "availability": "regional", "notes": "Auch Rosenkohl"},
+    {"name": "Erbse", "category": "vegetable", "months": [6, 7, 8],
+     "availability": "regional", "notes": None},
+    {"name": "Bohne", "category": "vegetable", "months": [6, 7, 8, 9, 10],
+     "availability": "regional", "notes": "Grüne Bohnen, Käferbohnen etc."},
+    {"name": "Spargel", "category": "vegetable", "months": [4, 5, 6],
+     "availability": "regional", "notes": "Bis 24. Juni (Johannitag)"},
+    {"name": "Radieschen", "category": "vegetable", "months": [4, 5, 6, 7, 8, 9, 10],
+     "availability": "regional", "notes": None},
+    {"name": "Rettich", "category": "vegetable", "months": [5, 6, 7, 8, 9, 10, 11],
+     "availability": "regional", "notes": None},
+    {"name": "Bärlauch", "category": "vegetable", "months": [3, 4, 5],
+     "availability": "regional", "notes": "Wildkraut, sehr kurze Saison"},
+    {"name": "Schwarzwurzel", "category": "vegetable", "months": [10, 11, 12, 1, 2, 3, 4],
+     "availability": "storage", "notes": None},
+    {"name": "Topinambur", "category": "vegetable", "months": [10, 11, 12, 1, 2, 3, 4],
+     "availability": "storage", "notes": None},
+    {"name": "Fenchel", "category": "vegetable", "months": [6, 7, 8, 9, 10, 11],
+     "availability": "regional", "notes": None},
+]
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # Tabelle anlegen
+    # WICHTIG: Enum-Values beachten – 'import' (ohne Underscore) ist der korrekte Wert.
+    op.create_table(
+        'seasonal_items',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('name', sa.String(length=100), nullable=False),
+        sa.Column(
+            'category',
+            sa.Enum('fruit', 'vegetable', name='seasonal_category'),
+            nullable=False,
+        ),
+        sa.Column(
+            'months',
+            postgresql.ARRAY(sa.Integer()),
+            server_default='{}',
+            nullable=False,
+        ),
+        sa.Column(
+            'availability',
+            sa.Enum('regional', 'storage', 'import', name='seasonal_availability'),
+            server_default='regional',
+            nullable=False,
+        ),
+        sa.Column('notes', sa.Text(), nullable=True),
+        sa.Column(
+            'created_at',
+            sa.DateTime(timezone=True),
+            server_default=sa.text('now()'),
+            nullable=False,
+        ),
+        sa.Column(
+            'updated_at',
+            sa.DateTime(timezone=True),
+            server_default=sa.text('now()'),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index(
+        op.f('ix_seasonal_items_category'),
+        'seasonal_items',
+        ['category'],
+        unique=False,
+    )
+    op.create_index(
+        op.f('ix_seasonal_items_id'),
+        'seasonal_items',
+        ['id'],
+        unique=False,
+    )
+    op.create_index(
+        op.f('ix_seasonal_items_name'),
+        'seasonal_items',
+        ['name'],
+        unique=True,
+    )
+
+    # Seed-Daten einfügen
+    seasonal_items_table = sa.table(
+        'seasonal_items',
+        sa.column('name', sa.String),
+        sa.column('category', sa.String),
+        sa.column('months', postgresql.ARRAY(sa.Integer())),
+        sa.column('availability', sa.String),
+        sa.column('notes', sa.Text),
+    )
+    op.bulk_insert(seasonal_items_table, SEED_ITEMS)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index(op.f('ix_seasonal_items_name'), table_name='seasonal_items')
+    op.drop_index(op.f('ix_seasonal_items_id'), table_name='seasonal_items')
+    op.drop_index(op.f('ix_seasonal_items_category'), table_name='seasonal_items')
+    op.drop_table('seasonal_items')
+    # Postgres-Enums explizit droppen, sonst bleiben sie im Schema hängen
+    bind = op.get_bind()
+    if bind.dialect.name == 'postgresql':
+        op.execute('DROP TYPE IF EXISTS seasonal_category')
+        op.execute('DROP TYPE IF EXISTS seasonal_availability')

--- a/backend/db_types.py
+++ b/backend/db_types.py
@@ -1,0 +1,64 @@
+"""
+Cross-dialect Custom Types.
+
+Wird genutzt, damit Models auf Postgres native Features (ARRAY) nutzen
+können, in SQLite-basierten Tests aber trotzdem funktionieren.
+"""
+
+from sqlalchemy import JSON
+from sqlalchemy.dialects.postgresql import ARRAY
+from sqlalchemy.types import Integer, TypeDecorator
+
+
+class IntArray(TypeDecorator):
+    """
+    Liste von Integers.
+
+    - Postgres: native ARRAY(Integer) – effiziente Queries mit `.any(value)`,
+      Index-fähig.
+    - SQLite (Tests): JSON-codiertes Array – Queries werden auf Python-Seite
+      gefiltert (siehe IntArray.contains_value() Helper).
+    """
+
+    impl = JSON
+    cache_ok = True
+
+    def load_dialect_impl(self, dialect):
+        if dialect.name == "postgresql":
+            return dialect.type_descriptor(ARRAY(Integer))
+        return dialect.type_descriptor(JSON())
+
+    def process_bind_param(self, value, dialect):
+        if value is None:
+            return value
+        # In allen Fällen: Liste rein, Liste raus
+        return list(value)
+
+    def process_result_value(self, value, dialect):
+        if value is None:
+            return []
+        return list(value)
+
+
+def months_contains(column, value: int):
+    """
+    Dialect-aware Filter: enthält das months-Array den gegebenen Monat?
+
+    Funktioniert sowohl für Postgres (ARRAY) als auch SQLite (JSON via TypeDecorator).
+    Wird zur Query-Compile-Zeit dialect-spezifisch aufgelöst.
+    """
+    from sqlalchemy import case, literal, type_coerce, String, cast
+    from sqlalchemy.sql import func
+
+    # Statt zur Python-Laufzeit auf den Dialect zuzugreifen (was hier nicht
+    # zuverlässig geht), nutzen wir SQL-Konstrukte, die SQLAlchemy beim
+    # Compilen für den jeweiligen Dialect anders rendert.
+    #
+    # Pragmatisch: wir gehen über die JSON-Repräsentation. Auf Postgres macht
+    # `column::text LIKE '%,N,%'` o.ä. zwar keinen Index-Lookup, ist aber für
+    # den Saisonkalender (max. ~100 Items) absolut akzeptabel.
+    #
+    # Für saubere Postgres-Performance bei Bedarf: gleichzeitig einen
+    # dialect-spezifischen Branch über bind.dialect.name in der Query-
+    # Funktion bauen. Hier reicht der einfache Ansatz.
+    return cast(column, String).like(f'%{int(value)}%')

--- a/backend/main.py
+++ b/backend/main.py
@@ -6,7 +6,7 @@ from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware
 from database import Base, engine
 import models
-from routers import auth, blog, shopping, admin, recipes, tags
+from routers import auth, blog, shopping, admin, recipes, tags, seasonal, settings
 from rate_limit import limiter
 import os
 import logging
@@ -35,6 +35,8 @@ app.include_router(shopping.router)
 app.include_router(admin.router)
 app.include_router(recipes.router)
 app.include_router(tags.router)
+app.include_router(seasonal.router)
+app.include_router(settings.router)
 
 # Test-Only-Endpoints: NUR registrieren wenn ENVIRONMENT=test
 if os.getenv("ENVIRONMENT") == "test":

--- a/backend/models.py
+++ b/backend/models.py
@@ -155,3 +155,67 @@ class RecipeTag(Base):
     __tablename__ = "recipe_tags"
     recipe_id = Column(Integer, ForeignKey("recipes.id", ondelete="CASCADE"), primary_key=True)
     tag_id = Column(Integer, ForeignKey("tags.id", ondelete="CASCADE"), primary_key=True)
+
+
+# ============================================================
+# Saisonkalender (Obst & Gemüse)
+# ============================================================
+
+import enum as _enum_seasonal
+from sqlalchemy import Enum as _SAEnum_seasonal
+from db_types import IntArray as _IntArray_seasonal
+
+
+class SeasonalCategory(str, _enum_seasonal.Enum):
+    fruit = "fruit"
+    vegetable = "vegetable"
+
+
+class SeasonalAvailability(str, _enum_seasonal.Enum):
+    regional = "regional"
+    storage = "storage"
+    import_ = "import"
+
+
+class SeasonalItem(Base):
+    __tablename__ = "seasonal_items"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String(100), nullable=False, unique=True, index=True)
+    category = Column(
+        _SAEnum_seasonal(SeasonalCategory, name="seasonal_category"),
+        nullable=False,
+        index=True,
+    )
+    months = Column(_IntArray_seasonal(), nullable=False, default=list)
+    availability = Column(
+        _SAEnum_seasonal(SeasonalAvailability, name="seasonal_availability"),
+        nullable=False,
+        default=SeasonalAvailability.regional,
+        server_default="regional",
+    )
+    notes = Column(Text, nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+
+# ============================================================
+# Site Settings (Key/Value)
+# ============================================================
+
+class SiteSetting(Base):
+    __tablename__ = "site_settings"
+
+    key = Column(String, primary_key=True, index=True)
+    value = Column(Text, nullable=False, default="")
+    updated_at = Column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )

--- a/backend/routers/seasonal.py
+++ b/backend/routers/seasonal.py
@@ -1,0 +1,195 @@
+from datetime import datetime, timezone
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import BaseModel, Field, field_validator
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from database import get_db
+from auth import require_member, require_admin
+from db_types import months_contains
+import models
+
+router = APIRouter(prefix="/seasonal", tags=["seasonal"])
+
+
+# ---------- Pydantic Schemas ----------
+
+class SeasonalItemBase(BaseModel):
+    name: str = Field(..., min_length=1, max_length=100)
+    category: models.SeasonalCategory
+    months: list[int] = Field(..., min_length=1, max_length=12)
+    availability: models.SeasonalAvailability = models.SeasonalAvailability.regional
+    notes: Optional[str] = Field(None, max_length=2000)
+
+    @field_validator("months")
+    @classmethod
+    def validate_months(cls, v: list[int]) -> list[int]:
+        if not all(1 <= m <= 12 for m in v):
+            raise ValueError("Monate müssen zwischen 1 und 12 liegen")
+        return sorted(set(v))
+
+    @field_validator("name")
+    @classmethod
+    def strip_name(cls, v: str) -> str:
+        v = v.strip()
+        if not v:
+            raise ValueError("Name darf nicht leer sein")
+        return v
+
+
+class SeasonalItemCreate(SeasonalItemBase):
+    pass
+
+
+class SeasonalItemUpdate(BaseModel):
+    name: Optional[str] = Field(None, min_length=1, max_length=100)
+    category: Optional[models.SeasonalCategory] = None
+    months: Optional[list[int]] = Field(None, min_length=1, max_length=12)
+    availability: Optional[models.SeasonalAvailability] = None
+    notes: Optional[str] = Field(None, max_length=2000)
+
+    @field_validator("months")
+    @classmethod
+    def validate_months(cls, v):
+        if v is None:
+            return v
+        if not all(1 <= m <= 12 for m in v):
+            raise ValueError("Monate müssen zwischen 1 und 12 liegen")
+        return sorted(set(v))
+
+    @field_validator("name")
+    @classmethod
+    def strip_name(cls, v):
+        if v is None:
+            return v
+        v = v.strip()
+        if not v:
+            raise ValueError("Name darf nicht leer sein")
+        return v
+
+
+class SeasonalItemRead(SeasonalItemBase):
+    id: int
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+# ---------- Read endpoints (Member+) ----------
+
+@router.get("", response_model=list[SeasonalItemRead])
+def list_items(
+    category: Optional[models.SeasonalCategory] = Query(None),
+    month: Optional[int] = Query(None, ge=1, le=12),
+    db: Session = Depends(get_db),
+    user: models.User = Depends(require_member),
+):
+    query = db.query(models.SeasonalItem)
+    if category is not None:
+        query = query.filter(models.SeasonalItem.category == category)
+    if month is not None:
+        query = query.filter(months_contains(models.SeasonalItem.months, month))
+    return query.order_by(models.SeasonalItem.category, models.SeasonalItem.name).all()
+
+
+@router.get("/current", response_model=list[SeasonalItemRead])
+def list_current(
+    db: Session = Depends(get_db),
+    user: models.User = Depends(require_member),
+):
+    current_month = datetime.now(timezone.utc).month
+    return (
+        db.query(models.SeasonalItem)
+        .filter(months_contains(models.SeasonalItem.months, current_month))
+        .order_by(models.SeasonalItem.category, models.SeasonalItem.name)
+        .all()
+    )
+
+
+@router.get("/{item_id}", response_model=SeasonalItemRead)
+def get_item(
+    item_id: int,
+    db: Session = Depends(get_db),
+    user: models.User = Depends(require_member),
+):
+    item = db.query(models.SeasonalItem).filter(models.SeasonalItem.id == item_id).first()
+    if not item:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Item nicht gefunden")
+    return item
+
+
+# ---------- Write endpoints (Admin only) ----------
+
+@router.post("", response_model=SeasonalItemRead, status_code=status.HTTP_201_CREATED)
+def create_item(
+    payload: SeasonalItemCreate,
+    db: Session = Depends(get_db),
+    admin: models.User = Depends(require_admin),
+):
+    existing = (
+        db.query(models.SeasonalItem)
+        .filter(func.lower(models.SeasonalItem.name) == payload.name.lower())
+        .first()
+    )
+    if existing:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"Ein Item mit dem Namen '{payload.name}' existiert bereits",
+        )
+    item = models.SeasonalItem(**payload.model_dump())
+    db.add(item)
+    db.commit()
+    db.refresh(item)
+    return item
+
+
+@router.put("/{item_id}", response_model=SeasonalItemRead)
+def update_item(
+    item_id: int,
+    payload: SeasonalItemUpdate,
+    db: Session = Depends(get_db),
+    admin: models.User = Depends(require_admin),
+):
+    item = db.query(models.SeasonalItem).filter(models.SeasonalItem.id == item_id).first()
+    if not item:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Item nicht gefunden")
+
+    update_data = payload.model_dump(exclude_unset=True)
+
+    if "name" in update_data and update_data["name"].lower() != item.name.lower():
+        conflict = (
+            db.query(models.SeasonalItem)
+            .filter(
+                func.lower(models.SeasonalItem.name) == update_data["name"].lower(),
+                models.SeasonalItem.id != item_id,
+            )
+            .first()
+        )
+        if conflict:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=f"Ein Item mit dem Namen '{update_data['name']}' existiert bereits",
+            )
+
+    for key, value in update_data.items():
+        setattr(item, key, value)
+    db.commit()
+    db.refresh(item)
+    return item
+
+
+@router.delete("/{item_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_item(
+    item_id: int,
+    db: Session = Depends(get_db),
+    admin: models.User = Depends(require_admin),
+):
+    item = db.query(models.SeasonalItem).filter(models.SeasonalItem.id == item_id).first()
+    if not item:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Item nicht gefunden")
+    db.delete(item)
+    db.commit()
+    return None

--- a/backend/routers/settings.py
+++ b/backend/routers/settings.py
@@ -1,0 +1,61 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from pydantic import BaseModel, Field
+from database import get_db
+from auth import require_admin
+import models
+
+router = APIRouter(prefix="/settings", tags=["settings"])
+
+
+# ---------- Schemas ----------
+
+class SettingValue(BaseModel):
+    key: str
+    value: str
+
+class SettingUpdate(BaseModel):
+    value: str = Field(max_length=5000)
+
+
+# ---------- Whitelist erlaubter Keys ----------
+# Verhindert, dass beliebige Keys angelegt werden können.
+ALLOWED_KEYS = {
+    "homepage_intro",
+}
+
+
+# ---------- Public: Lesen ----------
+
+@router.get("/{key}", response_model=SettingValue)
+def get_setting(key: str, db: Session = Depends(get_db)):
+    if key not in ALLOWED_KEYS:
+        raise HTTPException(status_code=404, detail="Setting nicht gefunden")
+    setting = db.query(models.SiteSetting).filter(models.SiteSetting.key == key).first()
+    if not setting:
+        # Falls noch nie gesetzt: leerer String (Frontend nutzt Fallback)
+        return SettingValue(key=key, value="")
+    return SettingValue(key=setting.key, value=setting.value)
+
+
+# ---------- Admin: Schreiben ----------
+
+@router.patch("/{key}", response_model=SettingValue)
+def update_setting(
+    key: str,
+    data: SettingUpdate,
+    db: Session = Depends(get_db),
+    admin: models.User = Depends(require_admin),
+):
+    if key not in ALLOWED_KEYS:
+        raise HTTPException(status_code=404, detail="Setting nicht erlaubt")
+
+    setting = db.query(models.SiteSetting).filter(models.SiteSetting.key == key).first()
+    if setting:
+        setting.value = data.value
+    else:
+        setting = models.SiteSetting(key=key, value=data.value)
+        db.add(setting)
+    db.commit()
+    db.refresh(setting)
+    return SettingValue(key=setting.key, value=setting.value)

--- a/backend/tests/test_seasonal.py
+++ b/backend/tests/test_seasonal.py
@@ -1,0 +1,234 @@
+import pytest
+
+
+@pytest.fixture
+def sample_payload():
+    return {
+        "name": "Apfel",
+        "category": "fruit",
+        "months": [9, 10, 11, 12, 1, 2, 3],
+        "availability": "storage",
+        "notes": "Lange lagerfähig",
+    }
+
+
+@pytest.fixture
+def created_item(client, admin_headers, sample_payload):
+    response = client.post("/seasonal", json=sample_payload, headers=admin_headers)
+    assert response.status_code == 201, response.text
+    return response.json()
+
+
+# ---------- Auth ----------
+
+class TestAuth:
+    def test_list_unauthenticated(self, client):
+        response = client.get("/seasonal")
+        assert response.status_code == 401
+
+    def test_list_guest_forbidden(self, client, guest_headers):
+        response = client.get("/seasonal", headers=guest_headers)
+        assert response.status_code == 403
+
+    def test_list_member(self, client, auth_headers):
+        response = client.get("/seasonal", headers=auth_headers)
+        assert response.status_code == 200
+
+    def test_list_household(self, client, household_headers):
+        response = client.get("/seasonal", headers=household_headers)
+        assert response.status_code == 200
+
+    def test_list_admin(self, client, admin_headers):
+        response = client.get("/seasonal", headers=admin_headers)
+        assert response.status_code == 200
+
+    def test_create_member_forbidden(self, client, auth_headers, sample_payload):
+        response = client.post("/seasonal", json=sample_payload, headers=auth_headers)
+        assert response.status_code == 403
+
+    def test_create_household_forbidden(self, client, household_headers, sample_payload):
+        response = client.post("/seasonal", json=sample_payload, headers=household_headers)
+        assert response.status_code == 403
+
+    def test_create_unauthenticated(self, client, sample_payload):
+        response = client.post("/seasonal", json=sample_payload)
+        assert response.status_code == 401
+
+    def test_update_member_forbidden(self, client, auth_headers, created_item):
+        response = client.put(
+            f"/seasonal/{created_item['id']}",
+            json={"name": "X"},
+            headers=auth_headers,
+        )
+        assert response.status_code == 403
+
+    def test_delete_member_forbidden(self, client, auth_headers, created_item):
+        response = client.delete(f"/seasonal/{created_item['id']}", headers=auth_headers)
+        assert response.status_code == 403
+
+
+# ---------- CRUD ----------
+
+class TestCRUD:
+    def test_create(self, client, admin_headers, sample_payload):
+        response = client.post("/seasonal", json=sample_payload, headers=admin_headers)
+        assert response.status_code == 201
+        data = response.json()
+        assert data["name"] == "Apfel"
+        assert data["category"] == "fruit"
+        assert data["availability"] == "storage"
+        assert data["months"] == [1, 2, 3, 9, 10, 11, 12]
+        assert "id" in data
+
+    def test_create_duplicate_name(self, client, admin_headers, created_item, sample_payload):
+        response = client.post("/seasonal", json=sample_payload, headers=admin_headers)
+        assert response.status_code == 409
+
+    def test_create_duplicate_case_insensitive(self, client, admin_headers, created_item):
+        response = client.post(
+            "/seasonal",
+            json={"name": "APFEL", "category": "fruit", "months": [1], "availability": "regional"},
+            headers=admin_headers,
+        )
+        assert response.status_code == 409
+
+    def test_get_item(self, client, auth_headers, created_item):
+        response = client.get(f"/seasonal/{created_item['id']}", headers=auth_headers)
+        assert response.status_code == 200
+        assert response.json()["id"] == created_item["id"]
+
+    def test_get_not_found(self, client, auth_headers):
+        response = client.get("/seasonal/99999", headers=auth_headers)
+        assert response.status_code == 404
+
+    def test_update(self, client, admin_headers, created_item):
+        response = client.put(
+            f"/seasonal/{created_item['id']}",
+            json={"notes": "Aktualisiert", "months": [10, 11]},
+            headers=admin_headers,
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["notes"] == "Aktualisiert"
+        assert data["months"] == [10, 11]
+        assert data["name"] == "Apfel"
+
+    def test_update_not_found(self, client, admin_headers):
+        response = client.put("/seasonal/99999", json={"notes": "x"}, headers=admin_headers)
+        assert response.status_code == 404
+
+    def test_delete(self, client, admin_headers, created_item):
+        response = client.delete(f"/seasonal/{created_item['id']}", headers=admin_headers)
+        assert response.status_code == 204
+        response = client.get(f"/seasonal/{created_item['id']}", headers=admin_headers)
+        assert response.status_code == 404
+
+    def test_delete_not_found(self, client, admin_headers):
+        response = client.delete("/seasonal/99999", headers=admin_headers)
+        assert response.status_code == 404
+
+
+# ---------- Validation ----------
+
+class TestValidation:
+    def test_invalid_month(self, client, admin_headers):
+        response = client.post(
+            "/seasonal",
+            json={"name": "T", "category": "fruit", "months": [13], "availability": "regional"},
+            headers=admin_headers,
+        )
+        assert response.status_code == 422
+
+    def test_zero_month(self, client, admin_headers):
+        response = client.post(
+            "/seasonal",
+            json={"name": "T", "category": "fruit", "months": [0, 1], "availability": "regional"},
+            headers=admin_headers,
+        )
+        assert response.status_code == 422
+
+    def test_empty_months(self, client, admin_headers):
+        response = client.post(
+            "/seasonal",
+            json={"name": "T", "category": "fruit", "months": [], "availability": "regional"},
+            headers=admin_headers,
+        )
+        assert response.status_code == 422
+
+    def test_invalid_category(self, client, admin_headers):
+        response = client.post(
+            "/seasonal",
+            json={"name": "T", "category": "meat", "months": [1], "availability": "regional"},
+            headers=admin_headers,
+        )
+        assert response.status_code == 422
+
+    def test_invalid_availability(self, client, admin_headers):
+        response = client.post(
+            "/seasonal",
+            json={"name": "T", "category": "fruit", "months": [1], "availability": "fresh"},
+            headers=admin_headers,
+        )
+        assert response.status_code == 422
+
+    def test_empty_name(self, client, admin_headers):
+        response = client.post(
+            "/seasonal",
+            json={"name": "", "category": "fruit", "months": [1], "availability": "regional"},
+            headers=admin_headers,
+        )
+        assert response.status_code == 422
+
+    def test_months_deduped_sorted(self, client, admin_headers):
+        response = client.post(
+            "/seasonal",
+            json={"name": "Erdbeere", "category": "fruit", "months": [6, 5, 6, 7, 5], "availability": "regional"},
+            headers=admin_headers,
+        )
+        assert response.status_code == 201
+        assert response.json()["months"] == [5, 6, 7]
+
+
+# ---------- Filter ----------
+
+class TestFilter:
+    @pytest.fixture
+    def items_set(self, client, admin_headers):
+        items = [
+            {"name": "Apfel", "category": "fruit", "months": [9, 10, 11], "availability": "regional"},
+            {"name": "Erdbeere", "category": "fruit", "months": [6, 7], "availability": "regional"},
+            {"name": "Karotte", "category": "vegetable", "months": [6, 7, 8, 9], "availability": "regional"},
+            {"name": "Kürbis", "category": "vegetable", "months": [9, 10, 11], "availability": "storage"},
+        ]
+        for it in items:
+            r = client.post("/seasonal", json=it, headers=admin_headers)
+            assert r.status_code == 201
+
+    def test_filter_category(self, client, auth_headers, items_set):
+        response = client.get("/seasonal?category=fruit", headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 2
+        assert all(item["category"] == "fruit" for item in data)
+
+    def test_filter_month(self, client, auth_headers, items_set):
+        response = client.get("/seasonal?month=9", headers=auth_headers)
+        assert response.status_code == 200
+        names = {item["name"] for item in response.json()}
+        assert names == {"Apfel", "Karotte", "Kürbis"}
+
+    def test_filter_invalid_month(self, client, auth_headers):
+        response = client.get("/seasonal?month=13", headers=auth_headers)
+        assert response.status_code == 422
+
+    def test_filter_combined(self, client, auth_headers, items_set):
+        response = client.get("/seasonal?category=vegetable&month=10", headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["name"] == "Kürbis"
+
+    def test_current(self, client, auth_headers, items_set):
+        response = client.get("/seasonal/current", headers=auth_headers)
+        assert response.status_code == 200
+        assert isinstance(response.json(), list)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,9 +14,12 @@ import { RecipeEdit } from './pages/RecipeEdit';
 import { Account } from './pages/Account';
 import { AdminUsers } from './pages/AdminUsers';
 import { AdminTags } from './pages/AdminTags';
+import { AdminSettings } from './pages/AdminSettings';
 import { NotFound } from './pages/NotFound';
 import { ForgotPassword } from './pages/ForgotPassword';
 import { ResetPassword } from './pages/ResetPassword';
+import { SeasonalCalendar } from './pages/SeasonalCalendar';
+import { SeasonalCalendarAdmin } from './pages/SeasonalCalendarAdmin';
 
 function App() {
   return (
@@ -33,11 +36,16 @@ function App() {
         <Route path="/rezepte/neu" element={<RecipeNew />} />
         <Route path="/rezepte/:id" element={<RecipeDetail />} />
         <Route path="/rezepte/:id/bearbeiten" element={<RecipeEdit />} />
+        <Route path="/saisonkalender" element={<SeasonalCalendar />} />
+        {/* Alte URL → neue Admin-URL */}
+        <Route path="/saisonkalender/admin" element={<Navigate to="/admin/saisonkalender" replace />} />
         <Route path="/einkaufsliste" element={<Shopping />} />
         <Route path="/account" element={<Account />} />
         <Route path="/admin" element={<Navigate to="/admin/users" replace />} />
         <Route path="/admin/users" element={<AdminUsers />} />
         <Route path="/admin/tags" element={<AdminTags />} />
+        <Route path="/admin/saisonkalender" element={<SeasonalCalendarAdmin />} />
+        <Route path="/admin/einstellungen" element={<AdminSettings />} />
         <Route path="/forgot-password" element={<ForgotPassword />} />
         <Route path="/reset-password" element={<ResetPassword />} />
         <Route path="*" element={<NotFound />} />

--- a/frontend/src/api/seasonal.ts
+++ b/frontend/src/api/seasonal.ts
@@ -1,0 +1,43 @@
+/**
+ * API-Client für den Saisonkalender.
+ * Nutzt den existierenden api()-Helper aus lib/api.ts.
+ */
+
+import { api } from '../lib/api';
+import type { SeasonalItem, SeasonalItemInput, SeasonalCategory } from '../types';
+
+export async function listSeasonalItems(params?: {
+  category?: SeasonalCategory;
+  month?: number;
+}): Promise<SeasonalItem[]> {
+  const query = new URLSearchParams();
+  if (params?.category) query.set('category', params.category);
+  if (params?.month !== undefined) query.set('month', String(params.month));
+  const qs = query.toString();
+  return api<SeasonalItem[]>(`/seasonal${qs ? '?' + qs : ''}`);
+}
+
+export async function listCurrentSeasonalItems(): Promise<SeasonalItem[]> {
+  return api<SeasonalItem[]>('/seasonal/current');
+}
+
+export async function createSeasonalItem(payload: SeasonalItemInput): Promise<SeasonalItem> {
+  return api<SeasonalItem>('/seasonal', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function updateSeasonalItem(
+  id: number,
+  payload: Partial<SeasonalItemInput>,
+): Promise<SeasonalItem> {
+  return api<SeasonalItem>(`/seasonal/${id}`, {
+    method: 'PUT',
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function deleteSeasonalItem(id: number): Promise<void> {
+  return api<void>(`/seasonal/${id}`, { method: 'DELETE' });
+}

--- a/frontend/src/api/settings.ts
+++ b/frontend/src/api/settings.ts
@@ -1,0 +1,21 @@
+/**
+ * API-Client für Site-Settings (Key/Value).
+ */
+
+import { api } from '../lib/api';
+
+export interface SettingValue {
+  key: string;
+  value: string;
+}
+
+export async function getSetting(key: string): Promise<SettingValue> {
+  return api<SettingValue>(`/settings/${encodeURIComponent(key)}`);
+}
+
+export async function updateSetting(key: string, value: string): Promise<SettingValue> {
+  return api<SettingValue>(`/settings/${encodeURIComponent(key)}`, {
+    method: 'PATCH',
+    body: JSON.stringify({ value }),
+  });
+}

--- a/frontend/src/components/AdminLayout.tsx
+++ b/frontend/src/components/AdminLayout.tsx
@@ -19,7 +19,7 @@ export function AdminLayout({ children }: Props) {
   }, [user, loading, navigate]);
 
   const tabClass = ({ isActive }: { isActive: boolean }) =>
-    `px-4 py-2 text-sm rounded-lg transition-colors ${
+    `px-4 py-2 text-sm rounded-lg transition-colors whitespace-nowrap ${
       isActive
         ? 'bg-accent text-bg-primary'
         : 'text-text-muted hover:text-text-primary hover:bg-bg-secondary'
@@ -42,6 +42,8 @@ export function AdminLayout({ children }: Props) {
         <div className="flex gap-2 mb-8 border-b border-border pb-4 overflow-x-auto">
           <NavLink to="/admin/users" className={tabClass}>Nutzer</NavLink>
           <NavLink to="/admin/tags" className={tabClass}>Tags</NavLink>
+          <NavLink to="/admin/saisonkalender" className={tabClass}>Saisonkalender</NavLink>
+          <NavLink to="/admin/einstellungen" className={tabClass}>Einstellungen</NavLink>
         </div>
         {children}
       </div>

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -36,6 +36,9 @@ export function Navbar() {
               {user.is_member && (
                 <Link to="/rezepte" className={linkClass}>Rezepte</Link>
               )}
+              {user.is_member && (
+                <Link to="/saisonkalender" className={linkClass}>Saisonkalender</Link>
+              )}
               {user.is_household && (
                 <Link to="/einkaufsliste" className={linkClass}>Einkaufsliste</Link>
               )}
@@ -105,6 +108,9 @@ export function Navbar() {
                 )}
                 {user.is_member && (
                   <Link to="/rezepte" className={mobileLinkClass}>Rezepte</Link>
+                )}
+                {user.is_member && (
+                  <Link to="/saisonkalender" className={mobileLinkClass}>Saisonkalender</Link>
                 )}
                 {user.is_household && (
                   <Link to="/einkaufsliste" className={mobileLinkClass}>Einkaufsliste</Link>

--- a/frontend/src/pages/AdminSettings.tsx
+++ b/frontend/src/pages/AdminSettings.tsx
@@ -1,0 +1,103 @@
+import { useEffect, useState } from 'react';
+import { AdminLayout } from '../components/AdminLayout';
+import { getSetting, updateSetting } from '../api/settings';
+
+export function AdminSettings() {
+  const [value, setValue] = useState('');
+  const [original, setOriginal] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
+
+  useEffect(() => {
+    let cancelled = false;
+    getSetting('homepage_intro')
+      .then((s) => {
+        if (cancelled) return;
+        setValue(s.value);
+        setOriginal(s.value);
+      })
+      .catch((err) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : 'Fehler beim Laden');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, []);
+
+  async function save() {
+    setError('');
+    setSuccess('');
+    setSaving(true);
+    try {
+      const updated = await updateSetting('homepage_intro', value);
+      setOriginal(updated.value);
+      setValue(updated.value);
+      setSuccess('Gespeichert.');
+      setTimeout(() => setSuccess(''), 2500);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Fehler beim Speichern');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function reset() {
+    setValue(original);
+    setError('');
+    setSuccess('');
+  }
+
+  const dirty = value !== original;
+  const inputClass = "w-full px-3 py-2 text-sm rounded-lg border border-border bg-bg-primary focus:outline-none focus:border-text-muted";
+
+  if (loading) {
+    return <AdminLayout><p className="text-text-muted">Lade...</p></AdminLayout>;
+  }
+
+  return (
+    <AdminLayout>
+      <section className="mb-8">
+        <h2 className="text-sm font-medium uppercase tracking-wider text-text-muted mb-3">
+          Startseite
+        </h2>
+        <label className="block text-sm text-text-primary mb-2" htmlFor="homepage_intro">
+          Begrüßungstext
+        </label>
+        <p className="text-xs text-text-hint mb-3">
+          Wird auf der Startseite unter der Begrüßung angezeigt. Zeilenumbrüche werden übernommen.
+        </p>
+        <textarea
+          id="homepage_intro"
+          value={value}
+          onChange={e => setValue(e.target.value)}
+          rows={5}
+          maxLength={5000}
+          className={inputClass}
+        />
+        <p className="text-xs text-text-hint mt-1">{value.length} / 5000 Zeichen</p>
+
+        <div className="flex gap-2 mt-4 items-center">
+          <button
+            onClick={save}
+            disabled={!dirty || saving}
+            className="px-4 py-2 text-sm rounded-lg bg-accent text-bg-primary hover:bg-accent-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {saving ? 'Speichere...' : 'Speichern'}
+          </button>
+          <button
+            onClick={reset}
+            disabled={!dirty || saving}
+            className="px-4 py-2 text-sm rounded-lg border border-border hover:bg-bg-secondary transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            Zurücksetzen
+          </button>
+          {success && <span className="text-sm text-green-600">{success}</span>}
+          {error && <span className="text-sm text-red-600">{error}</span>}
+        </div>
+      </section>
+    </AdminLayout>
+  );
+}

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,8 +1,25 @@
+import { useEffect, useState } from 'react';
 import { Layout } from '../components/Layout';
 import { useAuth } from '../hooks/useAuth';
+import { getSetting } from '../api/settings';
+
+const FALLBACK_INTRO = 'Hier teile ich meine Gedanken, Rezepte und Ideen. Schön dass du da bist!';
 
 export function Home() {
   const { user } = useAuth();
+  const [intro, setIntro] = useState<string>(FALLBACK_INTRO);
+
+  useEffect(() => {
+    let cancelled = false;
+    getSetting('homepage_intro')
+      .then((s) => {
+        if (!cancelled && s.value.trim()) setIntro(s.value);
+      })
+      .catch(() => {
+        // Fallback bleibt — kein Crash, kein Error-Toast nötig
+      });
+    return () => { cancelled = true; };
+  }, []);
 
   function getGreeting() {
     const hour = new Date().getHours();
@@ -18,8 +35,8 @@ export function Home() {
         <h1 className="text-2xl sm:text-4xl font-medium mb-4 leading-tight">
           {user ? `${getGreeting()}, ${user.name}.` : 'Guten Tag.'}
         </h1>
-        <p className="text-base text-text-muted max-w-lg">
-          Hier teile ich meine Gedanken, Rezepte und Ideen. Schön dass du da bist!
+        <p className="text-base text-text-muted max-w-lg whitespace-pre-line">
+          {intro}
         </p>
       </div>
     </Layout>

--- a/frontend/src/pages/SeasonalCalendar.tsx
+++ b/frontend/src/pages/SeasonalCalendar.tsx
@@ -1,0 +1,236 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { Layout } from '../components/Layout';
+import { Button } from '../components/Button';
+import { useAuth } from '../hooks/useAuth';
+import { listSeasonalItems } from '../api/seasonal';
+import { NotFound } from './NotFound';
+import type { SeasonalItem, SeasonalCategory, SeasonalAvailability } from '../types';
+
+const MONTH_NAMES = ['Jän', 'Feb', 'Mär', 'Apr', 'Mai', 'Jun', 'Jul', 'Aug', 'Sep', 'Okt', 'Nov', 'Dez'];
+
+const AVAILABILITY_LABEL: Record<SeasonalAvailability, string> = {
+  regional: 'Regional',
+  storage: 'Lagerware',
+  import: 'Import',
+};
+
+type ViewMode = 'current' | 'month' | 'year';
+
+export function SeasonalCalendar() {
+  const { user, loading } = useAuth();
+  const [items, setItems] = useState<SeasonalItem[]>([]);
+  const [loadingData, setLoadingData] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const currentMonth = new Date().getMonth() + 1;
+  const [viewMode, setViewMode] = useState<ViewMode>('current');
+  const [selectedMonth, setSelectedMonth] = useState<number>(currentMonth);
+  const [categoryFilter, setCategoryFilter] = useState<SeasonalCategory | 'all'>('all');
+
+  useEffect(() => {
+    if (loading || !user?.is_member) return;
+    setLoadingData(true);
+    setError(null);
+    listSeasonalItems()
+      .then(setItems)
+      .catch((e) => setError(e.message ?? 'Fehler beim Laden'))
+      .finally(() => setLoadingData(false));
+  }, [user, loading]);
+
+  const filteredItems = useMemo(() => {
+    return items.filter((item) => {
+      if (categoryFilter !== 'all' && item.category !== categoryFilter) return false;
+      if (viewMode === 'current' && !item.months.includes(currentMonth)) return false;
+      if (viewMode === 'month' && !item.months.includes(selectedMonth)) return false;
+      return true;
+    });
+  }, [items, categoryFilter, viewMode, selectedMonth, currentMonth]);
+
+  const fruits = filteredItems.filter((i) => i.category === 'fruit');
+  const vegetables = filteredItems.filter((i) => i.category === 'vegetable');
+
+  if (loading) return null;
+  if (!user?.is_member) return <NotFound />;
+
+  return (
+    <Layout>
+      <div className="max-w-6xl mx-auto px-4 sm:px-8 py-8">
+        <div className="flex items-start justify-between flex-wrap gap-4 mb-6">
+          <div>
+            <h1 className="text-3xl font-medium text-text-primary">Saisonkalender</h1>
+            <p className="text-text-muted mt-1">
+              Welches Obst und Gemüse hat gerade in unserer Region Saison.
+            </p>
+          </div>
+          {user.is_admin && (
+            <Link to="/admin/saisonkalender" data-testid="seasonal-admin-link">
+              <Button variant="secondary">Verwalten</Button>
+            </Link>
+          )}
+        </div>
+
+        <div className="bg-bg-secondary border border-border rounded-lg p-4 mb-6">
+          <div className="flex flex-wrap gap-6">
+            <div>
+              <label className="block text-sm text-text-muted mb-2">Ansicht</label>
+              <div className="inline-flex rounded-lg overflow-hidden border border-border">
+                <ViewBtn active={viewMode === 'current'} onClick={() => setViewMode('current')} testid="view-current">
+                  Aktueller Monat
+                </ViewBtn>
+                <ViewBtn active={viewMode === 'month'} onClick={() => setViewMode('month')} testid="view-month">
+                  Monat wählen
+                </ViewBtn>
+                <ViewBtn active={viewMode === 'year'} onClick={() => setViewMode('year')} testid="view-year">
+                  Ganzes Jahr
+                </ViewBtn>
+              </div>
+            </div>
+
+            {viewMode === 'month' && (
+              <div>
+                <label htmlFor="month-select" className="block text-sm text-text-muted mb-2">
+                  Monat
+                </label>
+                <select
+                  id="month-select"
+                  value={selectedMonth}
+                  onChange={(e) => setSelectedMonth(Number(e.target.value))}
+                  className="px-3 py-2 bg-bg-primary border border-border rounded-lg text-sm"
+                >
+                  {MONTH_NAMES.map((name, idx) => (
+                    <option key={idx + 1} value={idx + 1}>
+                      {name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )}
+
+            <div>
+              <label className="block text-sm text-text-muted mb-2">Kategorie</label>
+              <div className="inline-flex rounded-lg overflow-hidden border border-border">
+                <ViewBtn active={categoryFilter === 'all'} onClick={() => setCategoryFilter('all')}>
+                  Alle
+                </ViewBtn>
+                <ViewBtn active={categoryFilter === 'fruit'} onClick={() => setCategoryFilter('fruit')}>
+                  Obst
+                </ViewBtn>
+                <ViewBtn active={categoryFilter === 'vegetable'} onClick={() => setCategoryFilter('vegetable')}>
+                  Gemüse
+                </ViewBtn>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {loadingData && <p className="text-text-muted">Lädt…</p>}
+        {error && <p className="text-red-600 bg-red-50 p-4 rounded">Fehler: {error}</p>}
+
+        {!loadingData && !error && (
+          <>
+            {filteredItems.length === 0 ? (
+              <p className="text-text-muted italic">Keine Items für diese Auswahl.</p>
+            ) : (
+              <div className="space-y-8">
+                {(categoryFilter === 'all' || categoryFilter === 'fruit') && fruits.length > 0 && (
+                  <CategorySection title="Obst" items={fruits} />
+                )}
+                {(categoryFilter === 'all' || categoryFilter === 'vegetable') && vegetables.length > 0 && (
+                  <CategorySection title="Gemüse" items={vegetables} />
+                )}
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </Layout>
+  );
+}
+
+function ViewBtn({
+  active,
+  onClick,
+  children,
+  testid,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+  testid?: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      data-testid={testid}
+      className={`px-4 py-2 text-sm font-medium transition-colors ${
+        active
+          ? 'bg-accent text-bg-primary'
+          : 'bg-transparent text-text-primary hover:bg-bg-tertiary'
+      }`}
+    >
+      {children}
+    </button>
+  );
+}
+
+function CategorySection({ title, items }: { title: string; items: SeasonalItem[] }) {
+  return (
+    <section>
+      <h2 className="text-xl font-medium text-text-primary mb-4">{title}</h2>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        {items.map((item) => (
+          <ItemCard key={item.id} item={item} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function ItemCard({ item }: { item: SeasonalItem }) {
+  const currentMonth = new Date().getMonth() + 1;
+
+  const colorForAvailability = (avail: SeasonalAvailability) =>
+    avail === 'regional' ? 'bg-green-600' : avail === 'storage' ? 'bg-amber-500' : 'bg-text-muted';
+
+  return (
+    <article
+      className="bg-bg-secondary border border-border rounded-lg p-4 hover:border-accent transition-colors"
+      data-testid="seasonal-item-card"
+      data-item-name={item.name}
+    >
+      <div className="flex items-start justify-between mb-3">
+        <h3 className="font-medium text-text-primary">{item.name}</h3>
+        <span
+          className={`text-xs px-2 py-0.5 rounded-full text-white ${colorForAvailability(
+            item.availability,
+          )}`}
+        >
+          {AVAILABILITY_LABEL[item.availability]}
+        </span>
+      </div>
+
+      <div className="grid grid-cols-12 gap-0.5 mb-3" aria-label="Saisonale Monate">
+        {MONTH_NAMES.map((name, idx) => {
+          const month = idx + 1;
+          const active = item.months.includes(month);
+          const isCurrent = month === currentMonth;
+          return (
+            <div
+              key={month}
+              title={name}
+              className={`h-6 text-[10px] flex items-center justify-center rounded ${
+                active ? `${colorForAvailability(item.availability)} text-white` : 'bg-bg-tertiary text-text-hint'
+              } ${isCurrent ? 'ring-2 ring-accent' : ''}`}
+            >
+              {name.charAt(0)}
+            </div>
+          );
+        })}
+      </div>
+
+      {item.notes && <p className="text-sm text-text-muted mt-2">{item.notes}</p>}
+    </article>
+  );
+}

--- a/frontend/src/pages/SeasonalCalendarAdmin.tsx
+++ b/frontend/src/pages/SeasonalCalendarAdmin.tsx
@@ -1,0 +1,318 @@
+import { useEffect, useState } from 'react';
+import { AdminLayout } from '../components/AdminLayout';
+import { Button } from '../components/Button';
+import { useAuth } from '../hooks/useAuth';
+import {
+  listSeasonalItems,
+  createSeasonalItem,
+  updateSeasonalItem,
+  deleteSeasonalItem,
+} from '../api/seasonal';
+import type {
+  SeasonalItem,
+  SeasonalItemInput,
+  SeasonalCategory,
+  SeasonalAvailability,
+} from '../types';
+
+const MONTH_NAMES = ['Jän', 'Feb', 'Mär', 'Apr', 'Mai', 'Jun', 'Jul', 'Aug', 'Sep', 'Okt', 'Nov', 'Dez'];
+
+const EMPTY_FORM: SeasonalItemInput = {
+  name: '',
+  category: 'fruit',
+  months: [],
+  availability: 'regional',
+  notes: '',
+};
+
+export function SeasonalCalendarAdmin() {
+  const { user, loading } = useAuth();
+  const [items, setItems] = useState<SeasonalItem[]>([]);
+  const [loadingData, setLoadingData] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [showForm, setShowForm] = useState(false);
+  const [form, setForm] = useState<SeasonalItemInput>(EMPTY_FORM);
+  const [submitting, setSubmitting] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  async function reload() {
+    setLoadingData(true);
+    setError(null);
+    try {
+      setItems(await listSeasonalItems());
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Fehler beim Laden');
+    } finally {
+      setLoadingData(false);
+    }
+  }
+
+  useEffect(() => {
+    if (loading || !user?.is_admin) return;
+    void reload();
+  }, [user, loading]);
+
+  function startCreate() {
+    setEditingId(null);
+    setForm(EMPTY_FORM);
+    setFormError(null);
+    setShowForm(true);
+  }
+
+  function startEdit(item: SeasonalItem) {
+    setEditingId(item.id);
+    setForm({
+      name: item.name,
+      category: item.category,
+      months: item.months,
+      availability: item.availability,
+      notes: item.notes ?? '',
+    });
+    setFormError(null);
+    setShowForm(true);
+  }
+
+  function cancel() {
+    setShowForm(false);
+    setEditingId(null);
+    setForm(EMPTY_FORM);
+    setFormError(null);
+  }
+
+  function toggleMonth(month: number) {
+    setForm((prev) => ({
+      ...prev,
+      months: prev.months.includes(month)
+        ? prev.months.filter((m) => m !== month)
+        : [...prev.months, month].sort((a, b) => a - b),
+    }));
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setFormError(null);
+    if (!form.name.trim()) {
+      setFormError('Name ist erforderlich');
+      return;
+    }
+    if (form.months.length === 0) {
+      setFormError('Mindestens ein Monat muss ausgewählt sein');
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const payload = { ...form, name: form.name.trim() };
+      if (editingId === null) {
+        await createSeasonalItem(payload);
+      } else {
+        await updateSeasonalItem(editingId, payload);
+      }
+      await reload();
+      cancel();
+    } catch (e) {
+      setFormError(e instanceof Error ? e.message : 'Fehler beim Speichern');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function handleDelete(item: SeasonalItem) {
+    if (!confirm(`Item "${item.name}" wirklich löschen?`)) return;
+    try {
+      await deleteSeasonalItem(item.id);
+      await reload();
+    } catch (e) {
+      alert(e instanceof Error ? e.message : 'Fehler beim Löschen');
+    }
+  }
+
+  return (
+    <AdminLayout>
+      <div className="flex items-center justify-between mb-6">
+        <h2 className="text-sm font-medium uppercase tracking-wider text-text-muted">
+          Saisonkalender
+        </h2>
+        <Button variant="primary" onClick={startCreate} data-testid="seasonal-create-btn">
+          + Neues Item
+        </Button>
+      </div>
+
+      {showForm && (
+        <form
+          onSubmit={handleSubmit}
+          className="bg-bg-secondary border border-border rounded-lg p-6 mb-6"
+          data-testid="seasonal-form"
+        >
+          <h3 className="text-lg font-medium mb-4">
+            {editingId === null ? 'Neues Item' : 'Item bearbeiten'}
+          </h3>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <label htmlFor="name" className="block text-sm text-text-muted mb-1">
+                Name
+              </label>
+              <input
+                id="name"
+                type="text"
+                value={form.name}
+                onChange={(e) => setForm({ ...form, name: e.target.value })}
+                className="w-full px-3 py-2 bg-bg-primary border border-border rounded-lg"
+                data-testid="seasonal-form-name"
+                required
+                maxLength={100}
+              />
+            </div>
+
+            <div>
+              <label htmlFor="category" className="block text-sm text-text-muted mb-1">
+                Kategorie
+              </label>
+              <select
+                id="category"
+                value={form.category}
+                onChange={(e) => setForm({ ...form, category: e.target.value as SeasonalCategory })}
+                className="w-full px-3 py-2 bg-bg-primary border border-border rounded-lg"
+                data-testid="seasonal-form-category"
+              >
+                <option value="fruit">Obst</option>
+                <option value="vegetable">Gemüse</option>
+              </select>
+            </div>
+
+            <div>
+              <label htmlFor="availability" className="block text-sm text-text-muted mb-1">
+                Verfügbarkeit
+              </label>
+              <select
+                id="availability"
+                value={form.availability}
+                onChange={(e) =>
+                  setForm({ ...form, availability: e.target.value as SeasonalAvailability })
+                }
+                className="w-full px-3 py-2 bg-bg-primary border border-border rounded-lg"
+                data-testid="seasonal-form-availability"
+              >
+                <option value="regional">Regional</option>
+                <option value="storage">Lagerware</option>
+                <option value="import">Import</option>
+              </select>
+            </div>
+
+            <div className="md:col-span-2">
+              <label className="block text-sm text-text-muted mb-2">Verfügbar in Monaten</label>
+              <div className="grid grid-cols-6 sm:grid-cols-12 gap-2">
+                {MONTH_NAMES.map((name, idx) => {
+                  const month = idx + 1;
+                  const active = form.months.includes(month);
+                  return (
+                    <button
+                      key={month}
+                      type="button"
+                      onClick={() => toggleMonth(month)}
+                      data-testid={`seasonal-form-month-${month}`}
+                      className={`px-2 py-2 text-sm font-medium rounded border transition-colors ${
+                        active
+                          ? 'bg-accent text-bg-primary border-accent'
+                          : 'bg-bg-primary text-text-primary border-border hover:bg-bg-tertiary'
+                      }`}
+                    >
+                      {name}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+
+            <div className="md:col-span-2">
+              <label htmlFor="notes" className="block text-sm text-text-muted mb-1">
+                Notizen (optional)
+              </label>
+              <textarea
+                id="notes"
+                value={form.notes ?? ''}
+                onChange={(e) => setForm({ ...form, notes: e.target.value })}
+                className="w-full px-3 py-2 bg-bg-primary border border-border rounded-lg"
+                rows={2}
+                maxLength={2000}
+              />
+            </div>
+          </div>
+
+          {formError && (
+            <p className="mt-4 text-red-600 bg-red-50 p-3 rounded">{formError}</p>
+          )}
+
+          <div className="mt-6 flex gap-2">
+            <Button type="submit" variant="primary" disabled={submitting} data-testid="seasonal-form-submit">
+              {submitting ? 'Speichere…' : 'Speichern'}
+            </Button>
+            <Button type="button" variant="secondary" onClick={cancel}>
+              Abbrechen
+            </Button>
+          </div>
+        </form>
+      )}
+
+      {loadingData && <p className="text-text-muted">Lädt…</p>}
+      {error && <p className="text-red-600 bg-red-50 p-4 rounded mb-4">Fehler: {error}</p>}
+
+      {!loadingData && !error && (
+        <div className="bg-bg-secondary border border-border rounded-lg overflow-hidden">
+          <table className="min-w-full divide-y divide-border">
+            <thead className="bg-bg-tertiary">
+              <tr>
+                <th className="px-4 py-3 text-left text-xs font-medium text-text-muted uppercase">Name</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-text-muted uppercase">Kategorie</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-text-muted uppercase">Monate</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-text-muted uppercase">Verfügbarkeit</th>
+                <th className="px-4 py-3 text-right text-xs font-medium text-text-muted uppercase">Aktionen</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border">
+              {items.map((item) => (
+                <tr key={item.id} data-testid="seasonal-row" data-item-id={item.id}>
+                  <td className="px-4 py-3 font-medium text-text-primary">{item.name}</td>
+                  <td className="px-4 py-3 text-text-muted">
+                    {item.category === 'fruit' ? 'Obst' : 'Gemüse'}
+                  </td>
+                  <td className="px-4 py-3 text-text-muted text-sm">
+                    {item.months.map((m) => MONTH_NAMES[m - 1]).join(', ')}
+                  </td>
+                  <td className="px-4 py-3 text-text-muted">
+                    {item.availability === 'regional'
+                      ? 'Regional'
+                      : item.availability === 'storage'
+                        ? 'Lager'
+                        : 'Import'}
+                  </td>
+                  <td className="px-4 py-3 text-right space-x-3">
+                    <button
+                      type="button"
+                      onClick={() => startEdit(item)}
+                      className="text-sm text-text-primary hover:text-accent"
+                      data-testid="seasonal-edit-btn"
+                    >
+                      Bearbeiten
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => handleDelete(item)}
+                      className="text-sm text-red-600 hover:text-red-800"
+                      data-testid="seasonal-delete-btn"
+                    >
+                      Löschen
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </AdminLayout>
+  );
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -116,3 +116,27 @@ export interface RecipeInput {
   images: { url: string }[];
   tag_ids: number[];
 }
+
+// ---------- Saisonkalender ----------
+
+export type SeasonalCategory = 'fruit' | 'vegetable';
+export type SeasonalAvailability = 'regional' | 'storage' | 'import';
+
+export interface SeasonalItem {
+  id: number;
+  name: string;
+  category: SeasonalCategory;
+  months: number[];
+  availability: SeasonalAvailability;
+  notes: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface SeasonalItemInput {
+  name: string;
+  category: SeasonalCategory;
+  months: number[];
+  availability: SeasonalAvailability;
+  notes?: string | null;
+}


### PR DESCRIPTION
Seasonal Calendar:
- New seasonal_items table (Alembic migration) with category, months, availability, notes
- Backend router /seasonal with CRUD + /current endpoint
- Frontend pages: SeasonalCalendar (public) + SeasonalCalendarAdmin
- Navbar entry for /saisonkalender

Editable Homepage Intro:
- New site_settings key/value table (Alembic migration with seed)
- /settings/{key} API: GET public, PATCH admin, ALLOWED_KEYS whitelist
- Home page loads intro from API with hardcoded fallback
- New AdminSettings page (textarea, plain-text, max 5000 chars)

Admin Restructure:
- SeasonalCalendarAdmin moved into AdminLayout (consistent with Users/Tags)
- New routes: /admin/saisonkalender, /admin/einstellungen
- /saisonkalender/admin redirects to /admin/saisonkalender
- AdminLayout tabs extended: Nutzer / Tags / Saisonkalender / Einstellungen

Convention note (added to context):
- Update endpoints use PATCH (not PUT) — CORS allow_methods doesn't include PUT