### PR TITLE
Feature/seasonal multi availability

### DIFF
--- a/.claude/context.md
+++ b/.claude/context.md
@@ -168,6 +168,18 @@ auf das System. Daher:
 `docker compose logs -f backend` / `docker compose logs -f frontend`. Bei DB-Fragen:
 `docker compose exec db psql -U $POSTGRES_USER $POSTGRES_DB`.
 
+**Backend-Tests lokal laufen lassen**: dev-deps installieren mit
+`docker compose exec -T backend pip install -r requirements-dev.txt`
+(verschwinden bei nächstem Container-Restart, gewollt). Dann
+`docker compose exec -T backend python -m pytest --no-cov` —
+nicht `pytest` direkt, da installiert in `/home/app/.local/bin`
+(nicht im PATH).
+
+**Standalone-Maintenance-Skripte** liegen unter `backend/scripts/`,
+werden mit `docker compose exec -T backend python scripts/<name>.py`
+ausgeführt. Beispiel: `scripts/refine_seasonal_data.py`. Skripte
+sollten idempotent sein und einen `--dry-run`-Modus anbieten.
+
 **Neue Features** — Schlage Code vor, der zum bestehenden Stil passt
 (FastAPI-Router-Pattern, React-Function-Components mit Hooks, Tailwind-Klassen).
 Wenn DB-Schema betroffen ist: Alembic-Migration mitliefern.
@@ -209,6 +221,12 @@ CORS, Cloudflare-Konfig, Container-Hardening (read-only FS wo möglich, etc.).
   (siehe `backend/main.py`). Niemals `PUT` für neue Endpoints — Update-Konvention im
   Repo ist **PATCH** (siehe `routers/tags.py`, `routers/settings.py`). Wenn `PUT`
   wirklich nötig wird, muss `allow_methods` erweitert werden.
+- **SQLAlchemy-Enums mit reserved-word-Workaround**: Wenn ein Python-Enum-Member
+  einen Underscore-Suffix hat (z.B. `import_` mit value `"import"`, weil `import`
+  reserved word ist), muss bei der Spalten-Definition `values_callable=lambda e:
+  [m.value for m in e]` gesetzt werden. Sonst schreibt SQLAlchemy den
+  Member-Namen (`import_`) und Postgres-Enums lehnen ab. Beispiel siehe
+  `SeasonalAvailability` in `backend/models.py`.
 - Bei Schema-Änderungen IMMER vorher prüfen ob die Migration auch auf einer frischen
   DB läuft (E2E-Tests bauen DB von 0 auf). Lokal gegen einen Wegwerf-Postgres testen
   bevor pushen. Eine Migration die auf Prod funktioniert weil bestehende Tabellen da

--- a/backend/alembic/versions/seasonal_multi_availability.py
+++ b/backend/alembic/versions/seasonal_multi_availability.py
@@ -1,0 +1,178 @@
+"""seasonal_items: multi-availability via junction table
+
+Revision ID: f1a2b3c4d5e6
+Revises: a4c5274d72e4
+Create Date: 2026-04-28 18:30:00.000000
+
+Strukturänderung:
+- Bisher: seasonal_items.months (int[]) + seasonal_items.availability (single enum)
+- Neu:    seasonal_availabilities (item_id, month, type) als Junction Table
+
+Daten werden 1:1 migriert: jede (item, month)-Kombination bekommt den
+bisherigen availability-Wert als type. Verlustfrei, aber inhaltlich noch
+nicht "korrekter" — feinere Daten kommen über ein separates Seed-Skript.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'f1a2b3c4d5e6'
+down_revision: Union[str, Sequence[str], None] = 'a4c5274d72e4'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    bind = op.get_bind()
+
+    # Der Enum-Type 'seasonal_availability' existiert bereits in Postgres
+    # (von der ursprünglichen Migration). Wir referenzieren ihn ohne create_type=True,
+    # damit der Type NICHT neu erstellt wird.
+    availability_enum = postgresql.ENUM(
+        'regional', 'storage', 'import',
+        name='seasonal_availability',
+        create_type=False,
+    )
+
+    # 1) Neue Junction-Tabelle anlegen
+    op.create_table(
+        'seasonal_availabilities',
+        sa.Column('item_id', sa.Integer(), nullable=False),
+        sa.Column('month', sa.Integer(), nullable=False),
+        sa.Column('type', availability_enum, nullable=False),
+        sa.ForeignKeyConstraint(
+            ['item_id'], ['seasonal_items.id'],
+            ondelete='CASCADE',
+            name='fk_seasonal_avail_item',
+        ),
+        sa.PrimaryKeyConstraint('item_id', 'month', 'type', name='pk_seasonal_availabilities'),
+        sa.CheckConstraint('month >= 1 AND month <= 12', name='ck_seasonal_avail_month_range'),
+    )
+    op.create_index('ix_seasonal_avail_month', 'seasonal_availabilities', ['month'])
+    op.create_index('ix_seasonal_avail_type', 'seasonal_availabilities', ['type'])
+
+    # 2) Daten migrieren: für jede Zeile in seasonal_items einen Eintrag
+    # pro Monat in seasonal_availabilities mit dem bestehenden availability-Wert.
+    # Auf frischer DB ist das ein No-Op (E2E-safe).
+    if bind.dialect.name == 'postgresql':
+        op.execute(
+            """
+            INSERT INTO seasonal_availabilities (item_id, month, type)
+            SELECT id, unnest(months), availability
+            FROM seasonal_items
+            WHERE array_length(months, 1) IS NOT NULL
+            """
+        )
+    else:
+        # SQLite-Pfad (für lokales Testing wenn jemand alembic gegen SQLite laufen lässt)
+        # Production geht ausschließlich Postgres-Pfad.
+        result = bind.execute(sa.text("SELECT id, months, availability FROM seasonal_items"))
+        for row in result:
+            months = row.months or []
+            for m in months:
+                bind.execute(
+                    sa.text(
+                        "INSERT INTO seasonal_availabilities (item_id, month, type) "
+                        "VALUES (:iid, :m, :t)"
+                    ),
+                    {"iid": row.id, "m": m, "t": row.availability},
+                )
+
+    # 3) Alte Spalten droppen
+    op.drop_column('seasonal_items', 'months')
+    op.drop_column('seasonal_items', 'availability')
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    bind = op.get_bind()
+
+    availability_enum = postgresql.ENUM(
+        'regional', 'storage', 'import',
+        name='seasonal_availability',
+        create_type=False,
+    )
+
+    # 1) Alte Spalten wiederherstellen
+    op.add_column(
+        'seasonal_items',
+        sa.Column(
+            'months',
+            postgresql.ARRAY(sa.Integer()) if bind.dialect.name == 'postgresql' else sa.JSON(),
+            server_default='{}' if bind.dialect.name == 'postgresql' else None,
+            nullable=False,
+        ),
+    )
+    op.add_column(
+        'seasonal_items',
+        sa.Column(
+            'availability',
+            availability_enum,
+            server_default='regional',
+            nullable=False,
+        ),
+    )
+
+    # 2) Daten zurückspielen
+    # months: distinct Monate pro Item
+    # availability: "beste" Verfügbarkeit pro Item — Priorität regional > storage > import
+    if bind.dialect.name == 'postgresql':
+        op.execute(
+            """
+            UPDATE seasonal_items si
+            SET months = COALESCE(sub.months, ARRAY[]::int[])
+            FROM (
+                SELECT item_id, ARRAY_AGG(DISTINCT month ORDER BY month) AS months
+                FROM seasonal_availabilities
+                GROUP BY item_id
+            ) sub
+            WHERE si.id = sub.item_id
+            """
+        )
+        op.execute(
+            """
+            UPDATE seasonal_items si
+            SET availability = sub.best_type::seasonal_availability
+            FROM (
+                SELECT item_id,
+                    CASE
+                        WHEN bool_or(type = 'regional') THEN 'regional'
+                        WHEN bool_or(type = 'storage') THEN 'storage'
+                        ELSE 'import'
+                    END AS best_type
+                FROM seasonal_availabilities
+                GROUP BY item_id
+            ) sub
+            WHERE si.id = sub.item_id
+            """
+        )
+    else:
+        # SQLite-Pfad (analog, Python-seitig)
+        items = bind.execute(sa.text("SELECT DISTINCT item_id FROM seasonal_availabilities")).fetchall()
+        for (iid,) in items:
+            rows = bind.execute(
+                sa.text("SELECT month, type FROM seasonal_availabilities WHERE item_id = :iid"),
+                {"iid": iid},
+            ).fetchall()
+            months = sorted({r.month for r in rows})
+            types = {r.type for r in rows}
+            if 'regional' in types:
+                best = 'regional'
+            elif 'storage' in types:
+                best = 'storage'
+            else:
+                best = 'import'
+            bind.execute(
+                sa.text("UPDATE seasonal_items SET months = :m, availability = :a WHERE id = :iid"),
+                {"m": months, "a": best, "iid": iid},
+            )
+
+    # 3) Junction-Tabelle droppen
+    op.drop_index('ix_seasonal_avail_type', table_name='seasonal_availabilities')
+    op.drop_index('ix_seasonal_avail_month', table_name='seasonal_availabilities')
+    op.drop_table('seasonal_availabilities')

--- a/backend/models.py
+++ b/backend/models.py
@@ -183,7 +183,7 @@ class SeasonalItem(Base):
     id = Column(Integer, primary_key=True, index=True)
     name = Column(String(100), nullable=False, unique=True, index=True)
     category = Column(
-        _SAEnum_seasonal(SeasonalCategory, name="seasonal_category"),
+        _SAEnum_seasonal(SeasonalCategory, name="seasonal_category", values_callable=lambda e: [m.value for m in e]),
         nullable=False,
         index=True,
     )
@@ -219,7 +219,7 @@ class SeasonalAvailabilityEntry(Base):
     )
     month = Column(Integer, primary_key=True)
     type = Column(
-        _SAEnum_seasonal(SeasonalAvailability, name="seasonal_availability"),
+        _SAEnum_seasonal(SeasonalAvailability, name="seasonal_availability", values_callable=lambda e: [m.value for m in e]),
         primary_key=True,
     )
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, Boolean, DateTime, Text, ForeignKey, Float, UniqueConstraint
+from sqlalchemy import Column, Integer, String, Boolean, DateTime, Text, ForeignKey, Float, UniqueConstraint, CheckConstraint, Index
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
 from database import Base
@@ -187,13 +187,6 @@ class SeasonalItem(Base):
         nullable=False,
         index=True,
     )
-    months = Column(_IntArray_seasonal(), nullable=False, default=list)
-    availability = Column(
-        _SAEnum_seasonal(SeasonalAvailability, name="seasonal_availability"),
-        nullable=False,
-        default=SeasonalAvailability.regional,
-        server_default="regional",
-    )
     notes = Column(Text, nullable=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
     updated_at = Column(
@@ -202,6 +195,42 @@ class SeasonalItem(Base):
         onupdate=func.now(),
         nullable=False,
     )
+
+    availabilities = relationship(
+        "SeasonalAvailabilityEntry",
+        back_populates="item",
+        cascade="all, delete-orphan",
+        order_by="SeasonalAvailabilityEntry.month",
+    )
+
+
+class SeasonalAvailabilityEntry(Base):
+    """
+    Verfügbarkeits-Eintrag pro (Item, Monat, Typ).
+    Composite-PK: ein Item kann pro Monat mehrere Typen haben (z.B. regional + storage).
+    """
+
+    __tablename__ = "seasonal_availabilities"
+
+    item_id = Column(
+        Integer,
+        ForeignKey("seasonal_items.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    month = Column(Integer, primary_key=True)
+    type = Column(
+        _SAEnum_seasonal(SeasonalAvailability, name="seasonal_availability"),
+        primary_key=True,
+    )
+
+    item = relationship("SeasonalItem", back_populates="availabilities")
+
+    __table_args__ = (
+        CheckConstraint("month >= 1 AND month <= 12", name="ck_seasonal_avail_month_range"),
+        Index("ix_seasonal_avail_month", "month"),
+        Index("ix_seasonal_avail_type", "type"),
+    )
+
 
 
 # ============================================================

--- a/backend/routers/seasonal.py
+++ b/backend/routers/seasonal.py
@@ -1,14 +1,25 @@
+"""
+Seasonal Calendar API.
+
+Datenmodell:
+- SeasonalItem (id, name, category, notes, ...)
+- SeasonalAvailabilityEntry (item_id, month, type)  -- Composite-PK
+
+Pro (item, month) können mehrere types vorkommen (z.B. regional + storage).
+Im API-Schema werden die types pro Monat in einer Liste gruppiert.
+"""
+
+from collections import defaultdict
 from datetime import datetime, timezone
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field, field_validator
-from sqlalchemy import func
-from sqlalchemy.orm import Session
+from sqlalchemy import func, exists, and_
+from sqlalchemy.orm import Session, selectinload
 
 from database import get_db
 from auth import require_member, require_admin
-from db_types import months_contains
 import models
 
 router = APIRouter(prefix="/seasonal", tags=["seasonal"])
@@ -16,19 +27,37 @@ router = APIRouter(prefix="/seasonal", tags=["seasonal"])
 
 # ---------- Pydantic Schemas ----------
 
+class MonthAvailability(BaseModel):
+    """Verfügbarkeit eines Items in einem bestimmten Monat (mehrere Typen möglich)."""
+    month: int = Field(..., ge=1, le=12)
+    types: list[models.SeasonalAvailability] = Field(..., min_length=1)
+
+    @field_validator("types")
+    @classmethod
+    def dedupe_types(cls, v):
+        # Reihenfolge konsistent: regional, storage, import
+        order = {
+            models.SeasonalAvailability.regional: 0,
+            models.SeasonalAvailability.storage: 1,
+            models.SeasonalAvailability.import_: 2,
+        }
+        return sorted(set(v), key=lambda t: order[t])
+
+
 class SeasonalItemBase(BaseModel):
     name: str = Field(..., min_length=1, max_length=100)
     category: models.SeasonalCategory
-    months: list[int] = Field(..., min_length=1, max_length=12)
-    availability: models.SeasonalAvailability = models.SeasonalAvailability.regional
+    availabilities: list[MonthAvailability] = Field(..., min_length=1, max_length=12)
     notes: Optional[str] = Field(None, max_length=2000)
 
-    @field_validator("months")
+    @field_validator("availabilities")
     @classmethod
-    def validate_months(cls, v: list[int]) -> list[int]:
-        if not all(1 <= m <= 12 for m in v):
-            raise ValueError("Monate müssen zwischen 1 und 12 liegen")
-        return sorted(set(v))
+    def validate_unique_months(cls, v: list[MonthAvailability]):
+        months = [entry.month for entry in v]
+        if len(months) != len(set(months)):
+            raise ValueError("Jeder Monat darf nur einmal vorkommen")
+        # Nach Monat sortieren für konsistente Antworten
+        return sorted(v, key=lambda e: e.month)
 
     @field_validator("name")
     @classmethod
@@ -46,18 +75,18 @@ class SeasonalItemCreate(SeasonalItemBase):
 class SeasonalItemUpdate(BaseModel):
     name: Optional[str] = Field(None, min_length=1, max_length=100)
     category: Optional[models.SeasonalCategory] = None
-    months: Optional[list[int]] = Field(None, min_length=1, max_length=12)
-    availability: Optional[models.SeasonalAvailability] = None
+    availabilities: Optional[list[MonthAvailability]] = Field(None, min_length=1, max_length=12)
     notes: Optional[str] = Field(None, max_length=2000)
 
-    @field_validator("months")
+    @field_validator("availabilities")
     @classmethod
-    def validate_months(cls, v):
+    def validate_unique_months(cls, v):
         if v is None:
             return v
-        if not all(1 <= m <= 12 for m in v):
-            raise ValueError("Monate müssen zwischen 1 und 12 liegen")
-        return sorted(set(v))
+        months = [entry.month for entry in v]
+        if len(months) != len(set(months)):
+            raise ValueError("Jeder Monat darf nur einmal vorkommen")
+        return sorted(v, key=lambda e: e.month)
 
     @field_validator("name")
     @classmethod
@@ -70,12 +99,67 @@ class SeasonalItemUpdate(BaseModel):
         return v
 
 
-class SeasonalItemRead(SeasonalItemBase):
+class SeasonalItemRead(BaseModel):
     id: int
+    name: str
+    category: models.SeasonalCategory
+    availabilities: list[MonthAvailability]
+    notes: Optional[str]
     created_at: datetime
     updated_at: datetime
 
     model_config = {"from_attributes": True}
+
+
+# ---------- Helpers ----------
+
+def _serialize_item(item: models.SeasonalItem) -> SeasonalItemRead:
+    """ORM-Item -> Read-Schema mit gruppierten Monaten."""
+    by_month: dict[int, list[models.SeasonalAvailability]] = defaultdict(list)
+    for entry in item.availabilities:
+        by_month[entry.month].append(entry.type)
+
+    grouped = [
+        MonthAvailability(month=m, types=sorted(set(types), key=_avail_sort_key))
+        for m, types in sorted(by_month.items())
+    ]
+
+    return SeasonalItemRead(
+        id=item.id,
+        name=item.name,
+        category=item.category,
+        availabilities=grouped,
+        notes=item.notes,
+        created_at=item.created_at,
+        updated_at=item.updated_at,
+    )
+
+
+def _avail_sort_key(t: models.SeasonalAvailability) -> int:
+    order = {
+        models.SeasonalAvailability.regional: 0,
+        models.SeasonalAvailability.storage: 1,
+        models.SeasonalAvailability.import_: 2,
+    }
+    return order[t]
+
+
+def _replace_availabilities(
+    db: Session,
+    item: models.SeasonalItem,
+    payload: list[MonthAvailability],
+) -> None:
+    """Komplette Liste der Verfügbarkeiten ersetzen (delete + insert)."""
+    # Bestehende Einträge löschen (cascade-orphan macht das via Liste auch,
+    # aber explizit ist deutlicher)
+    item.availabilities.clear()
+    db.flush()
+
+    for entry in payload:
+        for t in entry.types:
+            item.availabilities.append(
+                models.SeasonalAvailabilityEntry(month=entry.month, type=t)
+            )
 
 
 # ---------- Read endpoints (Member+) ----------
@@ -84,15 +168,28 @@ class SeasonalItemRead(SeasonalItemBase):
 def list_items(
     category: Optional[models.SeasonalCategory] = Query(None),
     month: Optional[int] = Query(None, ge=1, le=12),
+    type: Optional[models.SeasonalAvailability] = Query(None),
     db: Session = Depends(get_db),
     user: models.User = Depends(require_member),
 ):
-    query = db.query(models.SeasonalItem)
+    query = (
+        db.query(models.SeasonalItem)
+        .options(selectinload(models.SeasonalItem.availabilities))
+    )
     if category is not None:
         query = query.filter(models.SeasonalItem.category == category)
-    if month is not None:
-        query = query.filter(months_contains(models.SeasonalItem.months, month))
-    return query.order_by(models.SeasonalItem.category, models.SeasonalItem.name).all()
+    if month is not None or type is not None:
+        # Subquery: existiert ein passender Eintrag in seasonal_availabilities?
+        avail_alias = models.SeasonalAvailabilityEntry
+        conditions = [avail_alias.item_id == models.SeasonalItem.id]
+        if month is not None:
+            conditions.append(avail_alias.month == month)
+        if type is not None:
+            conditions.append(avail_alias.type == type)
+        query = query.filter(exists().where(and_(*conditions)))
+
+    items = query.order_by(models.SeasonalItem.category, models.SeasonalItem.name).all()
+    return [_serialize_item(i) for i in items]
 
 
 @router.get("/current", response_model=list[SeasonalItemRead])
@@ -101,12 +198,22 @@ def list_current(
     user: models.User = Depends(require_member),
 ):
     current_month = datetime.now(timezone.utc).month
-    return (
+    avail_alias = models.SeasonalAvailabilityEntry
+    items = (
         db.query(models.SeasonalItem)
-        .filter(months_contains(models.SeasonalItem.months, current_month))
+        .options(selectinload(models.SeasonalItem.availabilities))
+        .filter(
+            exists().where(
+                and_(
+                    avail_alias.item_id == models.SeasonalItem.id,
+                    avail_alias.month == current_month,
+                )
+            )
+        )
         .order_by(models.SeasonalItem.category, models.SeasonalItem.name)
         .all()
     )
+    return [_serialize_item(i) for i in items]
 
 
 @router.get("/{item_id}", response_model=SeasonalItemRead)
@@ -115,10 +222,15 @@ def get_item(
     db: Session = Depends(get_db),
     user: models.User = Depends(require_member),
 ):
-    item = db.query(models.SeasonalItem).filter(models.SeasonalItem.id == item_id).first()
+    item = (
+        db.query(models.SeasonalItem)
+        .options(selectinload(models.SeasonalItem.availabilities))
+        .filter(models.SeasonalItem.id == item_id)
+        .first()
+    )
     if not item:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Item nicht gefunden")
-    return item
+    return _serialize_item(item)
 
 
 # ---------- Write endpoints (Admin only) ----------
@@ -139,26 +251,42 @@ def create_item(
             status_code=status.HTTP_409_CONFLICT,
             detail=f"Ein Item mit dem Namen '{payload.name}' existiert bereits",
         )
-    item = models.SeasonalItem(**payload.model_dump())
+
+    item = models.SeasonalItem(
+        name=payload.name,
+        category=payload.category,
+        notes=payload.notes,
+    )
+    for entry in payload.availabilities:
+        for t in entry.types:
+            item.availabilities.append(
+                models.SeasonalAvailabilityEntry(month=entry.month, type=t)
+            )
     db.add(item)
     db.commit()
     db.refresh(item)
-    return item
+    return _serialize_item(item)
 
 
-@router.put("/{item_id}", response_model=SeasonalItemRead)
+@router.patch("/{item_id}", response_model=SeasonalItemRead)
 def update_item(
     item_id: int,
     payload: SeasonalItemUpdate,
     db: Session = Depends(get_db),
     admin: models.User = Depends(require_admin),
 ):
-    item = db.query(models.SeasonalItem).filter(models.SeasonalItem.id == item_id).first()
+    item = (
+        db.query(models.SeasonalItem)
+        .options(selectinload(models.SeasonalItem.availabilities))
+        .filter(models.SeasonalItem.id == item_id)
+        .first()
+    )
     if not item:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Item nicht gefunden")
 
     update_data = payload.model_dump(exclude_unset=True)
 
+    # Name-Konflikt prüfen (case-insensitive, andere Items)
     if "name" in update_data and update_data["name"].lower() != item.name.lower():
         conflict = (
             db.query(models.SeasonalItem)
@@ -174,11 +302,21 @@ def update_item(
                 detail=f"Ein Item mit dem Namen '{update_data['name']}' existiert bereits",
             )
 
-    for key, value in update_data.items():
-        setattr(item, key, value)
+    # Skalare Felder
+    if "name" in update_data:
+        item.name = update_data["name"]
+    if "category" in update_data:
+        item.category = update_data["category"]
+    if "notes" in update_data:
+        item.notes = update_data["notes"]
+
+    # Availabilities — Replace-Semantik
+    if payload.availabilities is not None:
+        _replace_availabilities(db, item, payload.availabilities)
+
     db.commit()
     db.refresh(item)
-    return item
+    return _serialize_item(item)
 
 
 @router.delete("/{item_id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/scripts/refine_seasonal_data.py
+++ b/backend/scripts/refine_seasonal_data.py
@@ -1,0 +1,390 @@
+"""
+Seasonal Calendar: korrekte Verfügbarkeitsdaten für Österreich/Mitteleuropa.
+
+Ersetzt die Verfügbarkeiten der bestehenden seasonal_items mit handgepflegten
+Werten basierend auf österreichischen Saisonkalendern (AMA, Land schafft Leben).
+
+Format pro Item: {month_int: [type, ...]} mit type ∈ {"regional", "storage", "import"}
+- "regional" = heimisch frisch geerntet/verfügbar
+- "storage" = heimisch aus Lagerung
+- "import" = überwiegend Import aus dem Ausland
+
+Heuristik:
+- Frische Saison: nur regional
+- Lagerware-Klassiker: regional in Erntezeit + storage über Winter, ggf. import
+  im Übergang (z.B. Kartoffel-Frühkartoffel-Import)
+- Frischgemüse (Tomate, Paprika, Zucchini etc.): regional in Saison, sonst import
+- Beeren/Steinobst: regional in Saison, import in den Hauptmonaten der typischen
+  Importware (Erdbeere/Himbeere häufig importiert)
+
+Aufruf (im Backend-Container):
+  python scripts/refine_seasonal_data.py [--dry-run]
+
+Idempotent: kann mehrfach laufen, ersetzt jeweils komplett.
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+# Damit der Container-Import-Pfad passt: /app im sys.path
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from sqlalchemy.orm import sessionmaker  # noqa: E402
+
+from database import engine  # noqa: E402
+import models  # noqa: E402
+
+# Type-Aliases für Lesbarkeit
+R = "regional"
+L = "storage"
+I = "import"
+
+# ---------- Datendefinition ----------
+# Pro Item: dict[Monat 1..12] -> Liste von Verfügbarkeitstypen
+# Monate ohne Eintrag = nicht verfügbar
+
+# fmt: off
+ITEMS: dict[str, dict[int, list[str]]] = {
+    # ===== OBST =====
+    "Apfel": {
+        1: [L, I], 2: [L, I], 3: [L, I], 4: [L, I], 5: [I], 6: [I], 7: [I],
+        8: [R], 9: [R], 10: [R, L], 11: [L], 12: [L],
+    },
+    "Birne": {
+        1: [L, I], 2: [L, I], 3: [I], 4: [I], 5: [I], 6: [I], 7: [I],
+        8: [R], 9: [R], 10: [R, L], 11: [L], 12: [L, I],
+    },
+    "Erdbeere": {
+        1: [I], 2: [I], 3: [I], 4: [I], 5: [R], 6: [R], 7: [R],
+        8: [I], 9: [I], 10: [I], 11: [I], 12: [I],
+    },
+    "Himbeere": {
+        1: [I], 2: [I], 3: [I], 4: [I], 5: [I],
+        6: [R], 7: [R], 8: [R], 9: [R],
+        10: [I], 11: [I], 12: [I],
+    },
+    "Brombeere": {
+        7: [R], 8: [R], 9: [R],
+    },
+    "Heidelbeere": {
+        1: [I], 2: [I], 3: [I], 4: [I], 5: [I], 6: [I],
+        7: [R, I], 8: [R, I], 9: [R, I],
+        10: [I], 11: [I], 12: [I],
+    },
+    "Johannisbeere": {
+        6: [R], 7: [R], 8: [R],
+    },
+    "Stachelbeere": {
+        6: [R], 7: [R], 8: [R],
+    },
+    "Kirsche": {
+        6: [R], 7: [R], 8: [R],
+    },
+    "Marille": {
+        6: [R], 7: [R], 8: [R],
+    },
+    "Pfirsich": {
+        7: [R], 8: [R], 9: [R],
+    },
+    "Nektarine": {
+        7: [R], 8: [R], 9: [R],
+    },
+    "Pflaume": {
+        7: [R], 8: [R], 9: [R], 10: [R],
+    },
+    "Zwetschge": {
+        8: [R], 9: [R], 10: [R],
+    },
+    "Weintraube": {
+        8: [R], 9: [R], 10: [R], 11: [R],
+    },
+    "Rhabarber": {
+        4: [R], 5: [R], 6: [R],
+    },
+    "Quitte": {
+        9: [R], 10: [R], 11: [R],
+    },
+    "Holunderbeere": {
+        8: [R], 9: [R],
+    },
+
+    # ===== GEMÜSE =====
+    "Kartoffel": {
+        1: [L], 2: [L], 3: [L], 4: [L, I], 5: [L, I],
+        6: [R, L], 7: [R], 8: [R], 9: [R], 10: [R, L],
+        11: [L], 12: [L],
+    },
+    "Karotte": {
+        1: [L], 2: [L], 3: [L], 4: [L, I], 5: [I],
+        6: [R], 7: [R], 8: [R], 9: [R, L], 10: [R, L],
+        11: [L], 12: [L],
+    },
+    "Zwiebel": {
+        1: [L], 2: [L], 3: [L], 4: [L], 5: [L, I],
+        6: [I], 7: [R, I], 8: [R], 9: [R, L], 10: [R, L],
+        11: [L], 12: [L],
+    },
+    "Knoblauch": {
+        1: [L, I], 2: [L, I], 3: [I], 4: [I], 5: [I], 6: [I],
+        7: [R], 8: [R, L], 9: [L], 10: [L], 11: [L], 12: [L],
+    },
+    "Lauch": {
+        1: [R], 2: [R], 3: [R], 4: [R],
+        9: [R], 10: [R], 11: [R], 12: [R],
+    },
+    "Rote Rübe": {
+        1: [L], 2: [L], 3: [L],
+        6: [R], 7: [R], 8: [R], 9: [R, L], 10: [R, L],
+        11: [L], 12: [L],
+    },
+    "Sellerie": {
+        1: [L], 2: [L], 3: [L],
+        8: [R], 9: [R, L], 10: [R, L], 11: [L], 12: [L],
+    },
+    "Pastinake": {
+        1: [L], 2: [L], 3: [L],
+        10: [R, L], 11: [L], 12: [L],
+    },
+    "Kürbis": {
+        1: [L],
+        8: [R], 9: [R], 10: [R, L], 11: [L], 12: [L],
+    },
+    "Spinat": {
+        3: [R], 4: [R], 5: [R],
+        9: [R], 10: [R], 11: [R],
+    },
+    "Mangold": {
+        5: [R], 6: [R], 7: [R], 8: [R], 9: [R], 10: [R],
+    },
+    "Salat": {
+        1: [I], 2: [I], 3: [I],
+        4: [R], 5: [R], 6: [R], 7: [R], 8: [R], 9: [R], 10: [R],
+        11: [I], 12: [I],
+    },
+    "Vogerlsalat": {
+        1: [R], 2: [R], 3: [R],
+        10: [R], 11: [R], 12: [R],
+    },
+    "Chicorée": {
+        1: [R], 2: [R], 3: [R], 4: [R],
+        10: [R], 11: [R], 12: [R],
+    },
+    "Radicchio": {
+        6: [R], 7: [R], 8: [R], 9: [R], 10: [R], 11: [R], 12: [R],
+    },
+    "Rucola": {
+        4: [R], 5: [R], 6: [R], 7: [R], 8: [R], 9: [R], 10: [R],
+    },
+    "Tomate": {
+        1: [I], 2: [I], 3: [I], 4: [I], 5: [I],
+        6: [R], 7: [R], 8: [R], 9: [R], 10: [R],
+        11: [I], 12: [I],
+    },
+    "Gurke": {
+        1: [I], 2: [I], 3: [I], 4: [I], 5: [I],
+        6: [R], 7: [R], 8: [R], 9: [R], 10: [R],
+        11: [I], 12: [I],
+    },
+    "Paprika": {
+        1: [I], 2: [I], 3: [I], 4: [I], 5: [I], 6: [I],
+        7: [R], 8: [R], 9: [R], 10: [R],
+        11: [I], 12: [I],
+    },
+    "Zucchini": {
+        1: [I], 2: [I], 3: [I], 4: [I], 5: [I],
+        6: [R], 7: [R], 8: [R], 9: [R], 10: [R],
+        11: [I], 12: [I],
+    },
+    "Aubergine": {
+        1: [I], 2: [I], 3: [I], 4: [I], 5: [I], 6: [I],
+        7: [R], 8: [R], 9: [R], 10: [R],
+        11: [I], 12: [I],
+    },
+    "Brokkoli": {
+        1: [I], 2: [I], 3: [I], 4: [I], 5: [I],
+        6: [R], 7: [R], 8: [R], 9: [R], 10: [R],
+        11: [I], 12: [I],
+    },
+    "Karfiol": {
+        1: [I], 2: [I], 3: [I], 4: [I], 5: [I],
+        6: [R], 7: [R], 8: [R], 9: [R], 10: [R], 11: [R],
+        12: [I],
+    },
+    "Kohlrabi": {
+        5: [R], 6: [R], 7: [R], 8: [R], 9: [R], 10: [R],
+    },
+    "Weißkraut": {
+        1: [L], 2: [L], 3: [L],
+        6: [R], 7: [R], 8: [R], 9: [R, L], 10: [R, L],
+        11: [L], 12: [L],
+    },
+    "Rotkraut": {
+        1: [L], 2: [L], 3: [L],
+        9: [R], 10: [R, L], 11: [L], 12: [L],
+    },
+    "Wirsing": {
+        1: [L], 2: [L], 3: [L],
+        6: [R], 7: [R], 8: [R], 9: [R, L], 10: [R, L],
+        11: [L], 12: [L],
+    },
+    "Grünkohl": {
+        11: [R], 12: [R], 1: [R], 2: [R],
+    },
+    "Kohlsprossen": {
+        10: [R], 11: [R], 12: [R], 1: [R], 2: [R], 3: [R],
+    },
+    "Erbse": {
+        6: [R], 7: [R], 8: [R],
+    },
+    "Bohne": {
+        6: [R], 7: [R], 8: [R], 9: [R], 10: [R],
+    },
+    "Spargel": {
+        4: [R], 5: [R], 6: [R],
+    },
+    "Radieschen": {
+        4: [R], 5: [R], 6: [R], 7: [R], 8: [R], 9: [R], 10: [R],
+    },
+    "Rettich": {
+        5: [R], 6: [R], 7: [R], 8: [R], 9: [R], 10: [R], 11: [R],
+    },
+    "Bärlauch": {
+        3: [R], 4: [R], 5: [R],
+    },
+    "Schwarzwurzel": {
+        1: [L], 2: [L], 3: [L], 4: [L],
+        10: [R, L], 11: [L], 12: [L],
+    },
+    "Topinambur": {
+        1: [L], 2: [L], 3: [L], 4: [L],
+        10: [R, L], 11: [L], 12: [L],
+    },
+    "Fenchel": {
+        6: [R], 7: [R], 8: [R], 9: [R], 10: [R], 11: [R],
+    },
+}
+# fmt: on
+
+
+def _validate_data() -> list[str]:
+    """Sanity check der ITEMS-Struktur. Gibt eine Liste an Fehlermeldungen zurück."""
+    errors: list[str] = []
+    valid_types = {R, L, I}
+    for name, months in ITEMS.items():
+        if not months:
+            errors.append(f"{name}: keine Monate definiert")
+            continue
+        for m, types in months.items():
+            if not (1 <= m <= 12):
+                errors.append(f"{name}: Monat {m} außerhalb 1..12")
+            if not types:
+                errors.append(f"{name}: Monat {m} hat leere Type-Liste")
+            for t in types:
+                if t not in valid_types:
+                    errors.append(f"{name}: Monat {m} hat unbekannten Type '{t}'")
+            if len(types) != len(set(types)):
+                errors.append(f"{name}: Monat {m} hat Duplikate: {types}")
+    return errors
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Zeigt Änderungen, schreibt aber nicht in die DB",
+    )
+    args = parser.parse_args()
+
+    # 1) Validierung der hinterlegten Daten
+    errors = _validate_data()
+    if errors:
+        print("FEHLER in den Skript-Daten:")
+        for e in errors:
+            print(f"  - {e}")
+        sys.exit(1)
+
+    print(f"Skript enthält {len(ITEMS)} Items.")
+    if args.dry_run:
+        print("DRY-RUN: keine Änderungen werden geschrieben.\n")
+
+    # 2) DB-Session
+    Session = sessionmaker(bind=engine)
+    db = Session()
+
+    try:
+        # Alle Items aus DB
+        db_items = db.query(models.SeasonalItem).all()
+        db_by_name_lower = {i.name.lower(): i for i in db_items}
+
+        skript_names_lower = {n.lower() for n in ITEMS.keys()}
+
+        # 3) Items im Skript, die nicht in DB sind
+        missing_in_db = [n for n in ITEMS.keys() if n.lower() not in db_by_name_lower]
+        if missing_in_db:
+            print("Items im Skript, aber nicht in DB (übersprungen):")
+            for n in missing_in_db:
+                print(f"  - {n}")
+            print()
+
+        # 4) Items in DB, die nicht im Skript sind (zur Info — werden nicht angetastet)
+        extra_in_db = [i.name for i in db_items if i.name.lower() not in skript_names_lower]
+        if extra_in_db:
+            print("Items in DB, aber nicht im Skript (bleiben unverändert):")
+            for n in extra_in_db:
+                print(f"  - {n}")
+            print()
+
+        # 5) Updates durchführen
+        updated = 0
+        for name, months_data in ITEMS.items():
+            item = db_by_name_lower.get(name.lower())
+            if not item:
+                continue
+
+            # Komplett neue availabilities aufbauen
+            new_entries = []
+            for month, types in months_data.items():
+                for t in types:
+                    # Postgres-Enum erwartet die value-Strings (regional/storage/import)
+                    new_entries.append((month, t))
+
+            if args.dry_run:
+                old = sorted(
+                    {(a.month, a.type.value) for a in item.availabilities}
+                )
+                new = sorted(set(new_entries))
+                if old != new:
+                    print(f"[DRY] {item.name}:")
+                    print(f"      alt: {len(old)} Einträge")
+                    print(f"      neu: {len(new)} Einträge")
+                    updated += 1
+            else:
+                # Alte Einträge clearen, neue hinzufügen
+                item.availabilities.clear()
+                db.flush()
+                # Type-String → Enum-Member auflösen via _value2member_map_
+                avail_enum = models.SeasonalAvailability
+                for month, type_str in new_entries:
+                    enum_member = avail_enum(type_str)  # value-Lookup
+                    item.availabilities.append(
+                        models.SeasonalAvailabilityEntry(month=month, type=enum_member)
+                    )
+                updated += 1
+                print(f"  ✓ {item.name}: {len(new_entries)} Einträge")
+
+        if not args.dry_run:
+            db.commit()
+            print(f"\n{updated} Items aktualisiert. Commit erfolgreich.")
+        else:
+            print(f"\nDRY-RUN: {updated} Items würden aktualisiert.")
+
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/test_seasonal.py
+++ b/backend/tests/test_seasonal.py
@@ -104,6 +104,24 @@ class TestCRUD:
         assert _types_for_month(data, 1) == ["storage"]
         assert "id" in data
 
+    def test_create_with_import_type(self, client, admin_headers):
+        """Regression: 'import' als Wert (Python-Enum-Member heißt 'import_', Value 'import')."""
+        response = client.post(
+            "/seasonal",
+            json={
+                "name": "Banane", "category": "fruit",
+                "availabilities": [
+                    {"month": 1, "types": ["import"]},
+                    {"month": 6, "types": ["regional", "import"]},
+                ],
+            },
+            headers=admin_headers,
+        )
+        assert response.status_code == 201, response.text
+        data = response.json()
+        assert _types_for_month(data, 1) == ["import"]
+        assert _types_for_month(data, 6) == ["regional", "import"]
+
     def test_create_duplicate_name(self, client, admin_headers, created_item, sample_payload):
         response = client.post("/seasonal", json=sample_payload, headers=admin_headers)
         assert response.status_code == 409

--- a/backend/tests/test_seasonal.py
+++ b/backend/tests/test_seasonal.py
@@ -3,11 +3,21 @@ import pytest
 
 @pytest.fixture
 def sample_payload():
+    """Apfel: Aug-Okt regional + storage, Nov-Apr nur storage."""
     return {
         "name": "Apfel",
         "category": "fruit",
-        "months": [9, 10, 11, 12, 1, 2, 3],
-        "availability": "storage",
+        "availabilities": [
+            {"month": 1, "types": ["storage"]},
+            {"month": 2, "types": ["storage"]},
+            {"month": 3, "types": ["storage"]},
+            {"month": 4, "types": ["storage"]},
+            {"month": 8, "types": ["regional"]},
+            {"month": 9, "types": ["regional", "storage"]},
+            {"month": 10, "types": ["regional", "storage"]},
+            {"month": 11, "types": ["storage"]},
+            {"month": 12, "types": ["storage"]},
+        ],
         "notes": "Lange lagerfähig",
     }
 
@@ -17,6 +27,18 @@ def created_item(client, admin_headers, sample_payload):
     response = client.post("/seasonal", json=sample_payload, headers=admin_headers)
     assert response.status_code == 201, response.text
     return response.json()
+
+
+def _months_of(item: dict) -> list[int]:
+    """Hilfs-Extraktor für 'in welchen Monaten ist dieses Item irgendwie verfügbar'."""
+    return sorted(entry["month"] for entry in item["availabilities"])
+
+
+def _types_for_month(item: dict, month: int) -> list[str]:
+    for entry in item["availabilities"]:
+        if entry["month"] == month:
+            return entry["types"]
+    return []
 
 
 # ---------- Auth ----------
@@ -55,7 +77,7 @@ class TestAuth:
         assert response.status_code == 401
 
     def test_update_member_forbidden(self, client, auth_headers, created_item):
-        response = client.put(
+        response = client.patch(
             f"/seasonal/{created_item['id']}",
             json={"name": "X"},
             headers=auth_headers,
@@ -76,8 +98,10 @@ class TestCRUD:
         data = response.json()
         assert data["name"] == "Apfel"
         assert data["category"] == "fruit"
-        assert data["availability"] == "storage"
-        assert data["months"] == [1, 2, 3, 9, 10, 11, 12]
+        assert _months_of(data) == [1, 2, 3, 4, 8, 9, 10, 11, 12]
+        # Multi-Type pro Monat
+        assert _types_for_month(data, 9) == ["regional", "storage"]
+        assert _types_for_month(data, 1) == ["storage"]
         assert "id" in data
 
     def test_create_duplicate_name(self, client, admin_headers, created_item, sample_payload):
@@ -87,7 +111,11 @@ class TestCRUD:
     def test_create_duplicate_case_insensitive(self, client, admin_headers, created_item):
         response = client.post(
             "/seasonal",
-            json={"name": "APFEL", "category": "fruit", "months": [1], "availability": "regional"},
+            json={
+                "name": "APFEL",
+                "category": "fruit",
+                "availabilities": [{"month": 1, "types": ["regional"]}],
+            },
             headers=admin_headers,
         )
         assert response.status_code == 409
@@ -101,20 +129,55 @@ class TestCRUD:
         response = client.get("/seasonal/99999", headers=auth_headers)
         assert response.status_code == 404
 
-    def test_update(self, client, admin_headers, created_item):
-        response = client.put(
+    def test_update_partial(self, client, admin_headers, created_item):
+        """PATCH ohne availabilities: Notizen ändern, Verfügbarkeiten bleiben unverändert."""
+        original_avail = created_item["availabilities"]
+        response = client.patch(
             f"/seasonal/{created_item['id']}",
-            json={"notes": "Aktualisiert", "months": [10, 11]},
+            json={"notes": "Aktualisiert"},
             headers=admin_headers,
         )
         assert response.status_code == 200
         data = response.json()
         assert data["notes"] == "Aktualisiert"
-        assert data["months"] == [10, 11]
+        assert data["availabilities"] == original_avail
         assert data["name"] == "Apfel"
 
+    def test_update_replaces_availabilities(self, client, admin_headers, created_item):
+        """PATCH mit availabilities: kompletter Replace."""
+        response = client.patch(
+            f"/seasonal/{created_item['id']}",
+            json={
+                "availabilities": [
+                    {"month": 10, "types": ["regional"]},
+                    {"month": 11, "types": ["storage"]},
+                ]
+            },
+            headers=admin_headers,
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert _months_of(data) == [10, 11]
+        assert _types_for_month(data, 10) == ["regional"]
+        assert _types_for_month(data, 11) == ["storage"]
+
+    def test_update_change_multi_type(self, client, admin_headers, created_item):
+        """Bestehenden Monat von single auf multi-type ändern."""
+        response = client.patch(
+            f"/seasonal/{created_item['id']}",
+            json={
+                "availabilities": [
+                    {"month": 5, "types": ["regional", "import"]},
+                ]
+            },
+            headers=admin_headers,
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert _types_for_month(data, 5) == ["regional", "import"]
+
     def test_update_not_found(self, client, admin_headers):
-        response = client.put("/seasonal/99999", json={"notes": "x"}, headers=admin_headers)
+        response = client.patch("/seasonal/99999", json={"notes": "x"}, headers=admin_headers)
         assert response.status_code == 404
 
     def test_delete(self, client, admin_headers, created_item):
@@ -122,6 +185,19 @@ class TestCRUD:
         assert response.status_code == 204
         response = client.get(f"/seasonal/{created_item['id']}", headers=admin_headers)
         assert response.status_code == 404
+
+    def test_delete_cascades_availabilities(self, client, admin_headers, created_item, db_session):
+        """Beim Löschen eines Items werden zugehörige availabilities mitgelöscht (FK CASCADE)."""
+        import models as _models
+        item_id = created_item["id"]
+        before = db_session.query(_models.SeasonalAvailabilityEntry).filter_by(item_id=item_id).count()
+        assert before > 0
+
+        response = client.delete(f"/seasonal/{item_id}", headers=admin_headers)
+        assert response.status_code == 204
+
+        after = db_session.query(_models.SeasonalAvailabilityEntry).filter_by(item_id=item_id).count()
+        assert after == 0
 
     def test_delete_not_found(self, client, admin_headers):
         response = client.delete("/seasonal/99999", headers=admin_headers)
@@ -134,7 +210,10 @@ class TestValidation:
     def test_invalid_month(self, client, admin_headers):
         response = client.post(
             "/seasonal",
-            json={"name": "T", "category": "fruit", "months": [13], "availability": "regional"},
+            json={
+                "name": "T", "category": "fruit",
+                "availabilities": [{"month": 13, "types": ["regional"]}],
+            },
             headers=admin_headers,
         )
         assert response.status_code == 422
@@ -142,15 +221,43 @@ class TestValidation:
     def test_zero_month(self, client, admin_headers):
         response = client.post(
             "/seasonal",
-            json={"name": "T", "category": "fruit", "months": [0, 1], "availability": "regional"},
+            json={
+                "name": "T", "category": "fruit",
+                "availabilities": [{"month": 0, "types": ["regional"]}],
+            },
             headers=admin_headers,
         )
         assert response.status_code == 422
 
-    def test_empty_months(self, client, admin_headers):
+    def test_empty_availabilities(self, client, admin_headers):
         response = client.post(
             "/seasonal",
-            json={"name": "T", "category": "fruit", "months": [], "availability": "regional"},
+            json={"name": "T", "category": "fruit", "availabilities": []},
+            headers=admin_headers,
+        )
+        assert response.status_code == 422
+
+    def test_empty_types_per_month(self, client, admin_headers):
+        response = client.post(
+            "/seasonal",
+            json={
+                "name": "T", "category": "fruit",
+                "availabilities": [{"month": 1, "types": []}],
+            },
+            headers=admin_headers,
+        )
+        assert response.status_code == 422
+
+    def test_duplicate_month(self, client, admin_headers):
+        response = client.post(
+            "/seasonal",
+            json={
+                "name": "T", "category": "fruit",
+                "availabilities": [
+                    {"month": 5, "types": ["regional"]},
+                    {"month": 5, "types": ["storage"]},
+                ],
+            },
             headers=admin_headers,
         )
         assert response.status_code == 422
@@ -158,15 +265,21 @@ class TestValidation:
     def test_invalid_category(self, client, admin_headers):
         response = client.post(
             "/seasonal",
-            json={"name": "T", "category": "meat", "months": [1], "availability": "regional"},
+            json={
+                "name": "T", "category": "meat",
+                "availabilities": [{"month": 1, "types": ["regional"]}],
+            },
             headers=admin_headers,
         )
         assert response.status_code == 422
 
-    def test_invalid_availability(self, client, admin_headers):
+    def test_invalid_type(self, client, admin_headers):
         response = client.post(
             "/seasonal",
-            json={"name": "T", "category": "fruit", "months": [1], "availability": "fresh"},
+            json={
+                "name": "T", "category": "fruit",
+                "availabilities": [{"month": 1, "types": ["fresh"]}],
+            },
             headers=admin_headers,
         )
         assert response.status_code == 422
@@ -174,19 +287,29 @@ class TestValidation:
     def test_empty_name(self, client, admin_headers):
         response = client.post(
             "/seasonal",
-            json={"name": "", "category": "fruit", "months": [1], "availability": "regional"},
+            json={
+                "name": "", "category": "fruit",
+                "availabilities": [{"month": 1, "types": ["regional"]}],
+            },
             headers=admin_headers,
         )
         assert response.status_code == 422
 
-    def test_months_deduped_sorted(self, client, admin_headers):
+    def test_types_deduped(self, client, admin_headers):
+        """Doppelte types pro Monat werden serverseitig dedupliziert."""
         response = client.post(
             "/seasonal",
-            json={"name": "Erdbeere", "category": "fruit", "months": [6, 5, 6, 7, 5], "availability": "regional"},
+            json={
+                "name": "Erdbeere", "category": "fruit",
+                "availabilities": [
+                    {"month": 5, "types": ["regional", "regional", "storage"]},
+                ],
+            },
             headers=admin_headers,
         )
         assert response.status_code == 201
-        assert response.json()["months"] == [5, 6, 7]
+        data = response.json()
+        assert _types_for_month(data, 5) == ["regional", "storage"]
 
 
 # ---------- Filter ----------
@@ -195,10 +318,38 @@ class TestFilter:
     @pytest.fixture
     def items_set(self, client, admin_headers):
         items = [
-            {"name": "Apfel", "category": "fruit", "months": [9, 10, 11], "availability": "regional"},
-            {"name": "Erdbeere", "category": "fruit", "months": [6, 7], "availability": "regional"},
-            {"name": "Karotte", "category": "vegetable", "months": [6, 7, 8, 9], "availability": "regional"},
-            {"name": "Kürbis", "category": "vegetable", "months": [9, 10, 11], "availability": "storage"},
+            {
+                "name": "Apfel", "category": "fruit",
+                "availabilities": [
+                    {"month": 9, "types": ["regional"]},
+                    {"month": 10, "types": ["regional", "storage"]},
+                    {"month": 11, "types": ["storage"]},
+                ],
+            },
+            {
+                "name": "Erdbeere", "category": "fruit",
+                "availabilities": [
+                    {"month": 6, "types": ["regional"]},
+                    {"month": 7, "types": ["regional"]},
+                ],
+            },
+            {
+                "name": "Karotte", "category": "vegetable",
+                "availabilities": [
+                    {"month": 6, "types": ["regional"]},
+                    {"month": 7, "types": ["regional"]},
+                    {"month": 8, "types": ["regional"]},
+                    {"month": 9, "types": ["regional"]},
+                ],
+            },
+            {
+                "name": "Kürbis", "category": "vegetable",
+                "availabilities": [
+                    {"month": 9, "types": ["regional"]},
+                    {"month": 10, "types": ["regional", "storage"]},
+                    {"month": 11, "types": ["storage"]},
+                ],
+            },
         ]
         for it in items:
             r = client.post("/seasonal", json=it, headers=admin_headers)
@@ -222,11 +373,39 @@ class TestFilter:
         assert response.status_code == 422
 
     def test_filter_combined(self, client, auth_headers, items_set):
-        response = client.get("/seasonal?category=vegetable&month=10", headers=auth_headers)
+        response = client.get(
+            "/seasonal?category=vegetable&month=10", headers=auth_headers
+        )
         assert response.status_code == 200
         data = response.json()
         assert len(data) == 1
         assert data[0]["name"] == "Kürbis"
+
+    def test_filter_type_regional(self, client, auth_headers, items_set):
+        """Filter auf type=regional: alle Items mit mindestens einem regional-Eintrag."""
+        response = client.get("/seasonal?type=regional", headers=auth_headers)
+        assert response.status_code == 200
+        names = {item["name"] for item in response.json()}
+        assert names == {"Apfel", "Erdbeere", "Karotte", "Kürbis"}
+
+    def test_filter_type_storage(self, client, auth_headers, items_set):
+        response = client.get("/seasonal?type=storage", headers=auth_headers)
+        assert response.status_code == 200
+        names = {item["name"] for item in response.json()}
+        assert names == {"Apfel", "Kürbis"}
+
+    def test_filter_month_and_type(self, client, auth_headers, items_set):
+        """November + storage → Apfel und Kürbis."""
+        response = client.get("/seasonal?month=11&type=storage", headers=auth_headers)
+        assert response.status_code == 200
+        names = {item["name"] for item in response.json()}
+        assert names == {"Apfel", "Kürbis"}
+
+    def test_filter_month_and_type_no_match(self, client, auth_headers, items_set):
+        """November + regional → nichts (im Items-Set hat kein Item Nov-regional)."""
+        response = client.get("/seasonal?month=11&type=regional", headers=auth_headers)
+        assert response.status_code == 200
+        assert response.json() == []
 
     def test_current(self, client, auth_headers, items_set):
         response = client.get("/seasonal/current", headers=auth_headers)

--- a/frontend/src/api/seasonal.ts
+++ b/frontend/src/api/seasonal.ts
@@ -4,15 +4,22 @@
  */
 
 import { api } from '../lib/api';
-import type { SeasonalItem, SeasonalItemInput, SeasonalCategory } from '../types';
+import type {
+  SeasonalItem,
+  SeasonalItemInput,
+  SeasonalCategory,
+  SeasonalAvailability,
+} from '../types';
 
 export async function listSeasonalItems(params?: {
   category?: SeasonalCategory;
   month?: number;
+  type?: SeasonalAvailability;
 }): Promise<SeasonalItem[]> {
   const query = new URLSearchParams();
   if (params?.category) query.set('category', params.category);
   if (params?.month !== undefined) query.set('month', String(params.month));
+  if (params?.type) query.set('type', params.type);
   const qs = query.toString();
   return api<SeasonalItem[]>(`/seasonal${qs ? '?' + qs : ''}`);
 }
@@ -33,7 +40,7 @@ export async function updateSeasonalItem(
   payload: Partial<SeasonalItemInput>,
 ): Promise<SeasonalItem> {
   return api<SeasonalItem>(`/seasonal/${id}`, {
-    method: 'PUT',
+    method: 'PATCH',
     body: JSON.stringify(payload),
   });
 }

--- a/frontend/src/pages/SeasonalCalendar.tsx
+++ b/frontend/src/pages/SeasonalCalendar.tsx
@@ -5,17 +5,58 @@ import { Button } from '../components/Button';
 import { useAuth } from '../hooks/useAuth';
 import { listSeasonalItems } from '../api/seasonal';
 import { NotFound } from './NotFound';
-import type { SeasonalItem, SeasonalCategory, SeasonalAvailability } from '../types';
+import type {
+  SeasonalItem,
+  SeasonalCategory,
+  SeasonalAvailability,
+
+} from '../types';
 
 const MONTH_NAMES = ['Jän', 'Feb', 'Mär', 'Apr', 'Mai', 'Jun', 'Jul', 'Aug', 'Sep', 'Okt', 'Nov', 'Dez'];
 
 const AVAILABILITY_LABEL: Record<SeasonalAvailability, string> = {
-  regional: 'Regional',
+  regional: 'Saison',
   storage: 'Lagerware',
   import: 'Import',
 };
 
+const AVAILABILITY_COLOR: Record<SeasonalAvailability, string> = {
+  regional: 'bg-green-600',
+  storage: 'bg-amber-500',
+  import: 'bg-sky-600',
+};
+
+// Hex-Werte für inline gradient backgrounds (entsprechen den Tailwind-Farben oben)
+const AVAILABILITY_HEX: Record<SeasonalAvailability, string> = {
+  regional: '#16a34a',
+  storage: '#f59e0b',
+  import: '#0284c7',
+};
+
+const AVAILABILITY_ORDER: Record<SeasonalAvailability, number> = {
+  regional: 0,
+  storage: 1,
+  import: 2,
+};
+
 type ViewMode = 'current' | 'month' | 'year';
+type AvailabilityFilter = 'all' | SeasonalAvailability;
+
+function getAvailabilityForMonth(item: SeasonalItem, month: number): SeasonalAvailability[] {
+  return item.availabilities.find((a) => a.month === month)?.types ?? [];
+}
+
+function hasAvailability(item: SeasonalItem, month: number): boolean {
+  return getAvailabilityForMonth(item, month).length > 0;
+}
+
+function hasAvailabilityType(item: SeasonalItem, month: number, type: SeasonalAvailability): boolean {
+  return getAvailabilityForMonth(item, month).includes(type);
+}
+
+function sortTypes(types: SeasonalAvailability[]): SeasonalAvailability[] {
+  return [...types].sort((a, b) => AVAILABILITY_ORDER[a] - AVAILABILITY_ORDER[b]);
+}
 
 export function SeasonalCalendar() {
   const { user, loading } = useAuth();
@@ -27,6 +68,7 @@ export function SeasonalCalendar() {
   const [viewMode, setViewMode] = useState<ViewMode>('current');
   const [selectedMonth, setSelectedMonth] = useState<number>(currentMonth);
   const [categoryFilter, setCategoryFilter] = useState<SeasonalCategory | 'all'>('all');
+  const [availabilityFilter, setAvailabilityFilter] = useState<AvailabilityFilter>('all');
 
   useEffect(() => {
     if (loading || !user?.is_member) return;
@@ -41,17 +83,35 @@ export function SeasonalCalendar() {
   const filteredItems = useMemo(() => {
     return items.filter((item) => {
       if (categoryFilter !== 'all' && item.category !== categoryFilter) return false;
-      if (viewMode === 'current' && !item.months.includes(currentMonth)) return false;
-      if (viewMode === 'month' && !item.months.includes(selectedMonth)) return false;
+
+      // Monat-Filter (außer im Year-Modus)
+      const monthToCheck = viewMode === 'current' ? currentMonth : viewMode === 'month' ? selectedMonth : null;
+
+      if (monthToCheck !== null) {
+        if (availabilityFilter === 'all') {
+          if (!hasAvailability(item, monthToCheck)) return false;
+        } else {
+          if (!hasAvailabilityType(item, monthToCheck, availabilityFilter)) return false;
+        }
+      } else {
+        // Year-Modus: filter auf availabilityFilter über alle Monate
+        if (availabilityFilter !== 'all') {
+          const matches = item.availabilities.some((a) => a.types.includes(availabilityFilter));
+          if (!matches) return false;
+        }
+      }
+
       return true;
     });
-  }, [items, categoryFilter, viewMode, selectedMonth, currentMonth]);
+  }, [items, categoryFilter, viewMode, selectedMonth, currentMonth, availabilityFilter]);
 
   const fruits = filteredItems.filter((i) => i.category === 'fruit');
   const vegetables = filteredItems.filter((i) => i.category === 'vegetable');
 
   if (loading) return null;
   if (!user?.is_member) return <NotFound />;
+
+  const referenceMonth = viewMode === 'year' ? null : viewMode === 'current' ? currentMonth : selectedMonth;
 
   return (
     <Layout>
@@ -121,6 +181,45 @@ export function SeasonalCalendar() {
                 </ViewBtn>
               </div>
             </div>
+
+            <div>
+              <label className="block text-sm text-text-muted mb-2">Verfügbarkeit</label>
+              <div className="inline-flex rounded-lg overflow-hidden border border-border">
+                <ViewBtn
+                  active={availabilityFilter === 'all'}
+                  onClick={() => setAvailabilityFilter('all')}
+                  testid="avail-all"
+                >
+                  Alle
+                </ViewBtn>
+                <ViewBtn
+                  active={availabilityFilter === 'regional'}
+                  onClick={() => setAvailabilityFilter('regional')}
+                  testid="avail-regional"
+                >
+                  Saison
+                </ViewBtn>
+                <ViewBtn
+                  active={availabilityFilter === 'storage'}
+                  onClick={() => setAvailabilityFilter('storage')}
+                  testid="avail-storage"
+                >
+                  Lager
+                </ViewBtn>
+                <ViewBtn
+                  active={availabilityFilter === 'import'}
+                  onClick={() => setAvailabilityFilter('import')}
+                  testid="avail-import"
+                >
+                  Import
+                </ViewBtn>
+              </div>
+            </div>
+          </div>
+
+          {/* Legende */}
+          <div className="mt-4 flex flex-wrap gap-4 text-xs text-text-muted">
+            <LegendDot type="regional" /> <LegendDot type="storage" /> <LegendDot type="import" />
           </div>
         </div>
 
@@ -134,10 +233,10 @@ export function SeasonalCalendar() {
             ) : (
               <div className="space-y-8">
                 {(categoryFilter === 'all' || categoryFilter === 'fruit') && fruits.length > 0 && (
-                  <CategorySection title="Obst" items={fruits} />
+                  <CategorySection title="Obst" items={fruits} referenceMonth={referenceMonth} />
                 )}
                 {(categoryFilter === 'all' || categoryFilter === 'vegetable') && vegetables.length > 0 && (
-                  <CategorySection title="Gemüse" items={vegetables} />
+                  <CategorySection title="Gemüse" items={vegetables} referenceMonth={referenceMonth} />
                 )}
               </div>
             )}
@@ -175,24 +274,41 @@ function ViewBtn({
   );
 }
 
-function CategorySection({ title, items }: { title: string; items: SeasonalItem[] }) {
+function LegendDot({ type }: { type: SeasonalAvailability }) {
+  return (
+    <span className="inline-flex items-center gap-1.5">
+      <span className={`inline-block w-3 h-3 rounded-sm ${AVAILABILITY_COLOR[type]}`} />
+      {AVAILABILITY_LABEL[type]}
+    </span>
+  );
+}
+
+function CategorySection({
+  title,
+  items,
+  referenceMonth,
+}: {
+  title: string;
+  items: SeasonalItem[];
+  referenceMonth: number | null;
+}) {
   return (
     <section>
       <h2 className="text-xl font-medium text-text-primary mb-4">{title}</h2>
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
         {items.map((item) => (
-          <ItemCard key={item.id} item={item} />
+          <ItemCard key={item.id} item={item} referenceMonth={referenceMonth} />
         ))}
       </div>
     </section>
   );
 }
 
-function ItemCard({ item }: { item: SeasonalItem }) {
+function ItemCard({ item, referenceMonth }: { item: SeasonalItem; referenceMonth: number | null }) {
   const currentMonth = new Date().getMonth() + 1;
-
-  const colorForAvailability = (avail: SeasonalAvailability) =>
-    avail === 'regional' ? 'bg-green-600' : avail === 'storage' ? 'bg-amber-500' : 'bg-text-muted';
+  // Im Year-Modus zeigen wir den aktuellen Monat als "current", aber kein Badge
+  const badgeMonth = referenceMonth;
+  const badgeTypes = badgeMonth !== null ? sortTypes(getAvailabilityForMonth(item, badgeMonth)) : [];
 
   return (
     <article
@@ -200,29 +316,59 @@ function ItemCard({ item }: { item: SeasonalItem }) {
       data-testid="seasonal-item-card"
       data-item-name={item.name}
     >
-      <div className="flex items-start justify-between mb-3">
+      <div className="flex items-start justify-between mb-3 gap-2">
         <h3 className="font-medium text-text-primary">{item.name}</h3>
-        <span
-          className={`text-xs px-2 py-0.5 rounded-full text-white ${colorForAvailability(
-            item.availability,
-          )}`}
-        >
-          {AVAILABILITY_LABEL[item.availability]}
-        </span>
+        {badgeTypes.length > 0 && (
+          <div className="flex gap-1 flex-wrap justify-end">
+            {badgeTypes.map((t) => (
+              <span
+                key={t}
+                className={`text-[10px] px-2 py-0.5 rounded-full text-white whitespace-nowrap ${AVAILABILITY_COLOR[t]}`}
+              >
+                {AVAILABILITY_LABEL[t]}
+              </span>
+            ))}
+          </div>
+        )}
       </div>
 
       <div className="grid grid-cols-12 gap-0.5 mb-3" aria-label="Saisonale Monate">
         {MONTH_NAMES.map((name, idx) => {
           const month = idx + 1;
-          const active = item.months.includes(month);
+          const types = sortTypes(getAvailabilityForMonth(item, month));
           const isCurrent = month === currentMonth;
+          const isReference = referenceMonth !== null && month === referenceMonth;
+
+          // Hintergrund: gradient bei mehreren Types, solid bei einem, neutral bei keinem
+          const backgroundStyle: React.CSSProperties = (() => {
+            if (types.length === 0) return {};
+            if (types.length === 1) return { backgroundColor: AVAILABILITY_HEX[types[0]] };
+            // Vertikale Streifen via linear-gradient
+            const stops: string[] = [];
+            const step = 100 / types.length;
+            types.forEach((t, i) => {
+              const start = i * step;
+              const end = (i + 1) * step;
+              stops.push(`${AVAILABILITY_HEX[t]} ${start}% ${end}%`);
+            });
+            return { background: `linear-gradient(180deg, ${stops.join(', ')})` };
+          })();
+
+          const tooltip =
+            types.length === 0
+              ? `${name}: nicht verfügbar`
+              : `${name}: ${types.map((t) => AVAILABILITY_LABEL[t]).join(' + ')}`;
+
           return (
             <div
               key={month}
-              title={name}
+              title={tooltip}
+              data-month={month}
+              data-types={types.join(',')}
+              style={backgroundStyle}
               className={`h-6 text-[10px] flex items-center justify-center rounded ${
-                active ? `${colorForAvailability(item.availability)} text-white` : 'bg-bg-tertiary text-text-hint'
-              } ${isCurrent ? 'ring-2 ring-accent' : ''}`}
+                types.length === 0 ? 'bg-bg-tertiary text-text-hint' : 'text-white'
+              } ${isCurrent ? 'ring-2 ring-accent' : ''} ${isReference && !isCurrent ? 'ring-1 ring-accent/60' : ''}`}
             >
               {name.charAt(0)}
             </div>

--- a/frontend/src/pages/SeasonalCalendarAdmin.tsx
+++ b/frontend/src/pages/SeasonalCalendarAdmin.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState, useCallback } from 'react';
 import { AdminLayout } from '../components/AdminLayout';
 import { Button } from '../components/Button';
 import { useAuth } from '../hooks/useAuth';
@@ -13,17 +13,71 @@ import type {
   SeasonalItemInput,
   SeasonalCategory,
   SeasonalAvailability,
+  MonthAvailability,
 } from '../types';
 
-const MONTH_NAMES = ['Jän', 'Feb', 'Mär', 'Apr', 'Mai', 'Jun', 'Jul', 'Aug', 'Sep', 'Okt', 'Nov', 'Dez'];
+const MONTH_NAMES = ['Jänner', 'Februar', 'März', 'April', 'Mai', 'Juni', 'Juli', 'August', 'September', 'Oktober', 'November', 'Dezember'];
+const MONTH_SHORT = ['Jän', 'Feb', 'Mär', 'Apr', 'Mai', 'Jun', 'Jul', 'Aug', 'Sep', 'Okt', 'Nov', 'Dez'];
 
-const EMPTY_FORM: SeasonalItemInput = {
+const AVAILABILITY_OPTIONS: Array<{ value: SeasonalAvailability; label: string; color: string; hex: string }> = [
+  { value: 'regional', label: 'Saison', color: 'bg-green-600', hex: '#16a34a' },
+  { value: 'storage', label: 'Lager', color: 'bg-amber-500', hex: '#f59e0b' },
+  { value: 'import', label: 'Import', color: 'bg-sky-600', hex: '#0284c7' },
+];
+
+const AVAILABILITY_HEX: Record<SeasonalAvailability, string> = {
+  regional: '#16a34a',
+  storage: '#f59e0b',
+  import: '#0284c7',
+};
+
+const AVAILABILITY_ORDER: Record<SeasonalAvailability, number> = {
+  regional: 0,
+  storage: 1,
+  import: 2,
+};
+
+type MonthsState = Record<number, SeasonalAvailability[]>;
+
+const EMPTY_MONTHS: MonthsState = Object.fromEntries(
+  Array.from({ length: 12 }, (_, i) => [i + 1, []]),
+) as MonthsState;
+
+interface FormState {
+  name: string;
+  category: SeasonalCategory;
+  monthsState: MonthsState;
+  notes: string;
+}
+
+const EMPTY_FORM: FormState = {
   name: '',
   category: 'fruit',
-  months: [],
-  availability: 'regional',
+  monthsState: EMPTY_MONTHS,
   notes: '',
 };
+
+function availabilitiesToMonthsState(av: MonthAvailability[]): MonthsState {
+  const state: MonthsState = { ...EMPTY_MONTHS };
+  for (const entry of av) {
+    state[entry.month] = [...entry.types];
+  }
+  return state;
+}
+
+function monthsStateToAvailabilities(state: MonthsState): MonthAvailability[] {
+  const out: MonthAvailability[] = [];
+  for (let m = 1; m <= 12; m++) {
+    const types = state[m] ?? [];
+    if (types.length > 0) {
+      out.push({
+        month: m,
+        types: [...types].sort((a, b) => AVAILABILITY_ORDER[a] - AVAILABILITY_ORDER[b]),
+      });
+    }
+  }
+  return out;
+}
 
 export function SeasonalCalendarAdmin() {
   const { user, loading } = useAuth();
@@ -33,11 +87,11 @@ export function SeasonalCalendarAdmin() {
 
   const [editingId, setEditingId] = useState<number | null>(null);
   const [showForm, setShowForm] = useState(false);
-  const [form, setForm] = useState<SeasonalItemInput>(EMPTY_FORM);
+  const [form, setForm] = useState<FormState>(EMPTY_FORM);
   const [submitting, setSubmitting] = useState(false);
   const [formError, setFormError] = useState<string | null>(null);
 
-  async function reload() {
+  const reload = useCallback(async () => {
     setLoadingData(true);
     setError(null);
     try {
@@ -47,12 +101,12 @@ export function SeasonalCalendarAdmin() {
     } finally {
       setLoadingData(false);
     }
-  }
+  }, []);
 
   useEffect(() => {
     if (loading || !user?.is_admin) return;
     void reload();
-  }, [user, loading]);
+  }, [user, loading, reload]);
 
   function startCreate() {
     setEditingId(null);
@@ -66,28 +120,47 @@ export function SeasonalCalendarAdmin() {
     setForm({
       name: item.name,
       category: item.category,
-      months: item.months,
-      availability: item.availability,
+      monthsState: availabilitiesToMonthsState(item.availabilities),
       notes: item.notes ?? '',
     });
     setFormError(null);
     setShowForm(true);
   }
 
-  function cancel() {
+  const cancel = useCallback(() => {
     setShowForm(false);
     setEditingId(null);
     setForm(EMPTY_FORM);
     setFormError(null);
+  }, []);
+
+  // Esc schließt Modal + Body-Scroll-Lock
+  useEffect(() => {
+    if (!showForm) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && !submitting) cancel();
+    };
+    document.addEventListener('keydown', onKey);
+    const prevOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.removeEventListener('keydown', onKey);
+      document.body.style.overflow = prevOverflow;
+    };
+  }, [showForm, submitting, cancel]);
+
+  function toggleType(month: number, type: SeasonalAvailability) {
+    setForm((prev) => {
+      const current = prev.monthsState[month] ?? [];
+      const next = current.includes(type)
+        ? current.filter((t) => t !== type)
+        : [...current, type];
+      return { ...prev, monthsState: { ...prev.monthsState, [month]: next } };
+    });
   }
 
-  function toggleMonth(month: number) {
-    setForm((prev) => ({
-      ...prev,
-      months: prev.months.includes(month)
-        ? prev.months.filter((m) => m !== month)
-        : [...prev.months, month].sort((a, b) => a - b),
-    }));
+  function clearAllMonths() {
+    setForm((prev) => ({ ...prev, monthsState: EMPTY_MONTHS }));
   }
 
   async function handleSubmit(e: React.FormEvent) {
@@ -97,14 +170,20 @@ export function SeasonalCalendarAdmin() {
       setFormError('Name ist erforderlich');
       return;
     }
-    if (form.months.length === 0) {
-      setFormError('Mindestens ein Monat muss ausgewählt sein');
+    const availabilities = monthsStateToAvailabilities(form.monthsState);
+    if (availabilities.length === 0) {
+      setFormError('Mindestens ein Monat muss eine Verfügbarkeit haben');
       return;
     }
 
     setSubmitting(true);
     try {
-      const payload = { ...form, name: form.name.trim() };
+      const payload: SeasonalItemInput = {
+        name: form.name.trim(),
+        category: form.category,
+        availabilities,
+        notes: form.notes,
+      };
       if (editingId === null) {
         await createSeasonalItem(payload);
       } else {
@@ -129,6 +208,11 @@ export function SeasonalCalendarAdmin() {
     }
   }
 
+  const filledMonthsCount = useMemo(
+    () => Object.values(form.monthsState).filter((types) => types.length > 0).length,
+    [form.monthsState],
+  );
+
   return (
     <AdminLayout>
       <div className="flex items-center justify-between mb-6">
@@ -140,123 +224,6 @@ export function SeasonalCalendarAdmin() {
         </Button>
       </div>
 
-      {showForm && (
-        <form
-          onSubmit={handleSubmit}
-          className="bg-bg-secondary border border-border rounded-lg p-6 mb-6"
-          data-testid="seasonal-form"
-        >
-          <h3 className="text-lg font-medium mb-4">
-            {editingId === null ? 'Neues Item' : 'Item bearbeiten'}
-          </h3>
-
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <div>
-              <label htmlFor="name" className="block text-sm text-text-muted mb-1">
-                Name
-              </label>
-              <input
-                id="name"
-                type="text"
-                value={form.name}
-                onChange={(e) => setForm({ ...form, name: e.target.value })}
-                className="w-full px-3 py-2 bg-bg-primary border border-border rounded-lg"
-                data-testid="seasonal-form-name"
-                required
-                maxLength={100}
-              />
-            </div>
-
-            <div>
-              <label htmlFor="category" className="block text-sm text-text-muted mb-1">
-                Kategorie
-              </label>
-              <select
-                id="category"
-                value={form.category}
-                onChange={(e) => setForm({ ...form, category: e.target.value as SeasonalCategory })}
-                className="w-full px-3 py-2 bg-bg-primary border border-border rounded-lg"
-                data-testid="seasonal-form-category"
-              >
-                <option value="fruit">Obst</option>
-                <option value="vegetable">Gemüse</option>
-              </select>
-            </div>
-
-            <div>
-              <label htmlFor="availability" className="block text-sm text-text-muted mb-1">
-                Verfügbarkeit
-              </label>
-              <select
-                id="availability"
-                value={form.availability}
-                onChange={(e) =>
-                  setForm({ ...form, availability: e.target.value as SeasonalAvailability })
-                }
-                className="w-full px-3 py-2 bg-bg-primary border border-border rounded-lg"
-                data-testid="seasonal-form-availability"
-              >
-                <option value="regional">Regional</option>
-                <option value="storage">Lagerware</option>
-                <option value="import">Import</option>
-              </select>
-            </div>
-
-            <div className="md:col-span-2">
-              <label className="block text-sm text-text-muted mb-2">Verfügbar in Monaten</label>
-              <div className="grid grid-cols-6 sm:grid-cols-12 gap-2">
-                {MONTH_NAMES.map((name, idx) => {
-                  const month = idx + 1;
-                  const active = form.months.includes(month);
-                  return (
-                    <button
-                      key={month}
-                      type="button"
-                      onClick={() => toggleMonth(month)}
-                      data-testid={`seasonal-form-month-${month}`}
-                      className={`px-2 py-2 text-sm font-medium rounded border transition-colors ${
-                        active
-                          ? 'bg-accent text-bg-primary border-accent'
-                          : 'bg-bg-primary text-text-primary border-border hover:bg-bg-tertiary'
-                      }`}
-                    >
-                      {name}
-                    </button>
-                  );
-                })}
-              </div>
-            </div>
-
-            <div className="md:col-span-2">
-              <label htmlFor="notes" className="block text-sm text-text-muted mb-1">
-                Notizen (optional)
-              </label>
-              <textarea
-                id="notes"
-                value={form.notes ?? ''}
-                onChange={(e) => setForm({ ...form, notes: e.target.value })}
-                className="w-full px-3 py-2 bg-bg-primary border border-border rounded-lg"
-                rows={2}
-                maxLength={2000}
-              />
-            </div>
-          </div>
-
-          {formError && (
-            <p className="mt-4 text-red-600 bg-red-50 p-3 rounded">{formError}</p>
-          )}
-
-          <div className="mt-6 flex gap-2">
-            <Button type="submit" variant="primary" disabled={submitting} data-testid="seasonal-form-submit">
-              {submitting ? 'Speichere…' : 'Speichern'}
-            </Button>
-            <Button type="button" variant="secondary" onClick={cancel}>
-              Abbrechen
-            </Button>
-          </div>
-        </form>
-      )}
-
       {loadingData && <p className="text-text-muted">Lädt…</p>}
       {error && <p className="text-red-600 bg-red-50 p-4 rounded mb-4">Fehler: {error}</p>}
 
@@ -267,7 +234,6 @@ export function SeasonalCalendarAdmin() {
               <tr>
                 <th className="px-4 py-3 text-left text-xs font-medium text-text-muted uppercase">Name</th>
                 <th className="px-4 py-3 text-left text-xs font-medium text-text-muted uppercase">Kategorie</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-text-muted uppercase">Monate</th>
                 <th className="px-4 py-3 text-left text-xs font-medium text-text-muted uppercase">Verfügbarkeit</th>
                 <th className="px-4 py-3 text-right text-xs font-medium text-text-muted uppercase">Aktionen</th>
               </tr>
@@ -279,15 +245,8 @@ export function SeasonalCalendarAdmin() {
                   <td className="px-4 py-3 text-text-muted">
                     {item.category === 'fruit' ? 'Obst' : 'Gemüse'}
                   </td>
-                  <td className="px-4 py-3 text-text-muted text-sm">
-                    {item.months.map((m) => MONTH_NAMES[m - 1]).join(', ')}
-                  </td>
-                  <td className="px-4 py-3 text-text-muted">
-                    {item.availability === 'regional'
-                      ? 'Regional'
-                      : item.availability === 'storage'
-                        ? 'Lager'
-                        : 'Import'}
+                  <td className="px-4 py-3">
+                    <AvailabilityStrip item={item} />
                   </td>
                   <td className="px-4 py-3 text-right space-x-3">
                     <button
@@ -313,6 +272,238 @@ export function SeasonalCalendarAdmin() {
           </table>
         </div>
       )}
+
+      {showForm && (
+        <FormModal
+          title={editingId === null ? 'Neues Item' : 'Item bearbeiten'}
+          onClose={cancel}
+          submitting={submitting}
+        >
+          <form onSubmit={handleSubmit} data-testid="seasonal-form">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div>
+                <label htmlFor="name" className="block text-sm text-text-muted mb-1">
+                  Name
+                </label>
+                <input
+                  id="name"
+                  type="text"
+                  value={form.name}
+                  onChange={(e) => setForm({ ...form, name: e.target.value })}
+                  className="w-full px-3 py-2 bg-bg-primary border border-border rounded-lg"
+                  data-testid="seasonal-form-name"
+                  required
+                  maxLength={100}
+                  autoFocus
+                />
+              </div>
+
+              <div>
+                <label htmlFor="category" className="block text-sm text-text-muted mb-1">
+                  Kategorie
+                </label>
+                <select
+                  id="category"
+                  value={form.category}
+                  onChange={(e) => setForm({ ...form, category: e.target.value as SeasonalCategory })}
+                  className="w-full px-3 py-2 bg-bg-primary border border-border rounded-lg"
+                  data-testid="seasonal-form-category"
+                >
+                  <option value="fruit">Obst</option>
+                  <option value="vegetable">Gemüse</option>
+                </select>
+              </div>
+
+              <div className="md:col-span-2">
+                <div className="flex items-center justify-between mb-2">
+                  <label className="block text-sm text-text-muted">
+                    Verfügbarkeit pro Monat
+                  </label>
+                  <div className="flex items-center gap-3">
+                    <span className="text-xs text-text-muted">
+                      {filledMonthsCount} von 12 Monaten gepflegt
+                    </span>
+                    <button
+                      type="button"
+                      onClick={clearAllMonths}
+                      className="text-xs text-text-muted hover:text-text-primary underline"
+                      data-testid="seasonal-form-clear-months"
+                    >
+                      Alle leeren
+                    </button>
+                  </div>
+                </div>
+
+                <div className="border border-border rounded-lg overflow-hidden">
+                  <table className="w-full text-sm">
+                    <thead className="bg-bg-tertiary">
+                      <tr>
+                        <th className="text-left px-3 py-2 font-medium text-text-muted text-xs uppercase">Monat</th>
+                        {AVAILABILITY_OPTIONS.map((opt) => (
+                          <th key={opt.value} className="px-3 py-2 font-medium text-text-muted text-xs uppercase">
+                            <span className="inline-flex items-center gap-1.5">
+                              <span className={`inline-block w-3 h-3 rounded-sm ${opt.color}`} />
+                              {opt.label}
+                            </span>
+                          </th>
+                        ))}
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-border">
+                      {MONTH_NAMES.map((name, idx) => {
+                        const month = idx + 1;
+                        const types = form.monthsState[month] ?? [];
+                        return (
+                          <tr key={month} data-testid={`seasonal-form-row-${month}`}>
+                            <td className="px-3 py-2 font-medium">{name}</td>
+                            {AVAILABILITY_OPTIONS.map((opt) => {
+                              const active = types.includes(opt.value);
+                              return (
+                                <td key={opt.value} className="px-3 py-2 text-center">
+                                  <button
+                                    type="button"
+                                    onClick={() => toggleType(month, opt.value)}
+                                    data-testid={`seasonal-form-toggle-${month}-${opt.value}`}
+                                    aria-pressed={active}
+                                    className={`px-3 py-1 rounded-md text-xs font-medium border transition-colors ${
+                                      active
+                                        ? `${opt.color} text-white border-transparent`
+                                        : 'bg-bg-primary text-text-muted border-border hover:bg-bg-tertiary'
+                                    }`}
+                                  >
+                                    {active ? '✓' : '–'}
+                                  </button>
+                                </td>
+                              );
+                            })}
+                          </tr>
+                        );
+                      })}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+
+              <div className="md:col-span-2">
+                <label htmlFor="notes" className="block text-sm text-text-muted mb-1">
+                  Notizen (optional)
+                </label>
+                <textarea
+                  id="notes"
+                  value={form.notes}
+                  onChange={(e) => setForm({ ...form, notes: e.target.value })}
+                  className="w-full px-3 py-2 bg-bg-primary border border-border rounded-lg"
+                  rows={2}
+                  maxLength={2000}
+                />
+              </div>
+            </div>
+
+            {formError && (
+              <p className="mt-4 text-red-600 bg-red-50 p-3 rounded">{formError}</p>
+            )}
+
+            <div className="mt-6 flex justify-end gap-2">
+              <Button type="button" variant="secondary" onClick={cancel} disabled={submitting}>
+                Abbrechen
+              </Button>
+              <Button type="submit" variant="primary" disabled={submitting} data-testid="seasonal-form-submit">
+                {submitting ? 'Speichere…' : 'Speichern'}
+              </Button>
+            </div>
+          </form>
+        </FormModal>
+      )}
     </AdminLayout>
+  );
+}
+
+function FormModal({
+  title,
+  onClose,
+  submitting,
+  children,
+}: {
+  title: string;
+  onClose: () => void;
+  submitting: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-start sm:items-center justify-center p-4 sm:p-6"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="seasonal-form-title"
+      data-testid="seasonal-form-modal"
+    >
+      {/* Backdrop */}
+      <button
+        type="button"
+        onClick={() => !submitting && onClose()}
+        aria-label="Schließen"
+        className="fixed inset-0 bg-black/60 backdrop-blur-sm"
+      />
+      {/* Dialog */}
+      <div className="relative bg-bg-secondary border border-border rounded-lg shadow-2xl w-full max-w-3xl max-h-[90vh] flex flex-col">
+        <div className="flex items-center justify-between p-4 sm:p-6 border-b border-border">
+          <h3 id="seasonal-form-title" className="text-lg font-medium">
+            {title}
+          </h3>
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={submitting}
+            className="text-text-muted hover:text-text-primary text-xl leading-none px-2"
+            aria-label="Schließen"
+          >
+            ×
+          </button>
+        </div>
+        <div className="overflow-y-auto p-4 sm:p-6">{children}</div>
+      </div>
+    </div>
+  );
+}
+
+function AvailabilityStrip({ item }: { item: SeasonalItem }) {
+  return (
+    <div className="grid grid-cols-12 gap-0.5 max-w-[280px]">
+      {MONTH_SHORT.map((name, idx) => {
+        const month = idx + 1;
+        const types = (item.availabilities.find((a) => a.month === month)?.types ?? [])
+          .slice()
+          .sort((a, b) => AVAILABILITY_ORDER[a] - AVAILABILITY_ORDER[b]);
+
+        const style: React.CSSProperties = (() => {
+          if (types.length === 0) return {};
+          if (types.length === 1) return { backgroundColor: AVAILABILITY_HEX[types[0]] };
+          const stops: string[] = [];
+          const step = 100 / types.length;
+          types.forEach((t, i) => {
+            stops.push(`${AVAILABILITY_HEX[t]} ${i * step}% ${(i + 1) * step}%`);
+          });
+          return { background: `linear-gradient(180deg, ${stops.join(', ')})` };
+        })();
+
+        const tooltip =
+          types.length === 0
+            ? `${name}: -`
+            : `${name}: ${types.join(' + ')}`;
+
+        return (
+          <div
+            key={month}
+            title={tooltip}
+            style={style}
+            className={`h-5 text-[9px] flex items-center justify-center rounded ${
+              types.length === 0 ? 'bg-bg-tertiary text-text-hint' : 'text-white'
+            }`}
+          >
+            {name.charAt(0)}
+          </div>
+        );
+      })}
+    </div>
   );
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -122,12 +122,16 @@ export interface RecipeInput {
 export type SeasonalCategory = 'fruit' | 'vegetable';
 export type SeasonalAvailability = 'regional' | 'storage' | 'import';
 
+export interface MonthAvailability {
+  month: number; // 1..12
+  types: SeasonalAvailability[]; // mind. 1, sortiert: regional, storage, import
+}
+
 export interface SeasonalItem {
   id: number;
   name: string;
   category: SeasonalCategory;
-  months: number[];
-  availability: SeasonalAvailability;
+  availabilities: MonthAvailability[];
   notes: string | null;
   created_at: string;
   updated_at: string;
@@ -136,7 +140,6 @@ export interface SeasonalItem {
 export interface SeasonalItemInput {
   name: string;
   category: SeasonalCategory;
-  months: number[];
-  availability: SeasonalAvailability;
+  availabilities: MonthAvailability[];
   notes?: string | null;
 }


### PR DESCRIPTION
## Saisonkalender: Multi-Verfügbarkeit pro Monat

Bisher konnte pro Item nur **eine** Verfügbarkeit hinterlegt werden (regional / storage / import) sowie eine Liste an Saisonmonaten. Das war zu grob: ein Apfel ist von August bis Oktober regional, von November bis April Lagerware, im Mai/Juni Import — bisher ging das alles unter einem einzigen "storage"-Label.

### Schema-Änderung

Die Spalten `months: int[]` und `availability: enum` auf `seasonal_items` werden durch eine Junction Table `seasonal_availabilities (item_id, month, type)` ersetzt. Damit können pro `(Item, Monat)` mehrere Typen gleichzeitig hinterlegt werden — z.B. Apfel im September: `regional + storage`.

### API-Änderungen (breaking)

- Response-Shape: `availabilities: [{month: int, types: [enum]}]` statt `months[]` + `availability`
- `PUT /seasonal/{id}` → `PATCH /seasonal/{id}` (Repo-Konvention)
- Neuer optionaler Filter `?type=regional|storage|import` auf der List-Endpoint

### Frontend

- Public-Seite: pro Monat farbige Streifen, mehrere Types werden als Gradient-Bänder dargestellt. Neuer "Verfügbarkeit"-Filter (Alle/Saison/Lager/Import).
- Admin-Seite: Form als Modal (Esc/Backdrop schließt, Body-Scroll-Lock). Pro Monat drei Toggles (Saison/Lager/Import) — Mehrfachauswahl möglich.

### Daten-Migration

1. **Schema-Migration** (Alembic): überträgt die 56 bestehenden Items 1:1 ins neue Schema (jeder bisherige `availability`-Wert wird für jeden bestehenden Monat als Eintrag angelegt).
2. **Refine-Skript** (`scripts/refine_seasonal_data.py`): überschreibt die Verfügbarkeiten der 56 Items mit handgepflegten Werten basierend auf österreichischen Saisonkalendern. Idempotent, mit `--dry-run`-Option.

### Tests

- Backend: 41 Tests für `test_seasonal.py` (vorher 27), inkl. Regression-Test für `import` als Wert (Python-Enum-Member heißt `import_`, Value `import`)
- Volle Backend-Suite läuft grün (176 Tests)

### Stolperfallen / Notizen

- `SeasonalAvailability`-Enum braucht `values_callable=lambda e: [m.value for m in e]` in `models.py`, sonst schreibt SQLAlchemy `import_` statt `import` und Postgres lehnt ab.
- Migration ist auf frischer DB getestet (E2E-Pfad): wenn `seasonal_items` leer ist, ist der Datentransfer ein No-Op.