### PR TITLE
feat: Impostor party game (public + admin)

### DIFF
--- a/backend/alembic/versions/c7e8f9a0b1d2_add_impostor_game.py
+++ b/backend/alembic/versions/c7e8f9a0b1d2_add_impostor_game.py
@@ -1,0 +1,286 @@
+"""add impostor game tables and seed data
+
+Revision ID: c7e8f9a0b1d2
+Revises: f1a2b3c4d5e6
+Create Date: 2026-05-02 12:00:00.000000
+
+Schema:
+- impostor_categories (id, name unique, is_active, sort_order, created_at)
+- impostor_words      (id, category_id FK cascade, word, created_at,
+                       UNIQUE(category_id, word))
+
+Seed: 20 Kategorien × 30 Wörter = 600 Wörter.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'c7e8f9a0b1d2'
+down_revision: Union[str, Sequence[str], None] = 'f1a2b3c4d5e6'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+SEED_DATA: list[tuple[str, list[str]]] = [
+    ("Essen", [
+        "Pizza", "Spaghetti", "Wiener Schnitzel", "Sushi", "Hamburger",
+        "Lasagne", "Kaiserschmarrn", "Gulasch", "Apfelstrudel", "Tafelspitz",
+        "Käsespätzle", "Pommes frites", "Tiramisu", "Sachertorte", "Donut",
+        "Croissant", "Brezel", "Knödel", "Risotto", "Currywurst",
+        "Falafel", "Pad Thai", "Tacos", "Pancakes", "Bratwurst",
+        "Caesar Salad", "Ramen", "Pho", "Paella", "Ratatouille",
+    ]),
+    ("Tiere", [
+        "Elefant", "Löwe", "Pinguin", "Giraffe", "Känguru",
+        "Delfin", "Adler", "Schildkröte", "Krokodil", "Eichhörnchen",
+        "Igel", "Fuchs", "Wolf", "Bär", "Hai",
+        "Oktopus", "Schmetterling", "Biene", "Ameise", "Spinne",
+        "Pferd", "Kuh", "Schaf", "Ziege", "Hase",
+        "Papagei", "Eule", "Flamingo", "Faultier", "Panda",
+    ]),
+    ("Berufe", [
+        "Arzt", "Lehrer", "Polizist", "Feuerwehrmann", "Pilot",
+        "Koch", "Bäcker", "Metzger", "Tischler", "Friseur",
+        "Anwalt", "Architekt", "Journalist", "Programmierer", "Krankenpfleger",
+        "Bauer", "Briefträger", "Müllmann", "Maurer", "Elektriker",
+        "Klempner", "Mechaniker", "Schauspieler", "Sänger", "Künstler",
+        "Astronaut", "Bibliothekar", "Übersetzer", "Zahnarzt", "Tierarzt",
+    ]),
+    ("Orte/Länder", [
+        "Österreich", "Deutschland", "Italien", "Frankreich", "Spanien",
+        "Japan", "Brasilien", "Australien", "Kanada", "Ägypten",
+        "Indien", "Mexiko", "Norwegen", "Griechenland", "Türkei",
+        "Schweiz", "Portugal", "Niederlande", "Schweden", "Polen",
+        "Wien", "Paris", "Tokio", "New York", "London",
+        "Rom", "Berlin", "Sydney", "Reykjavík", "Kapstadt",
+    ]),
+    ("Filme/Serien", [
+        "Star Wars", "Harry Potter", "Der Pate", "Titanic", "Avatar",
+        "Inception", "Matrix", "Forrest Gump", "Jurassic Park", "Pulp Fiction",
+        "Breaking Bad", "Game of Thrones", "Stranger Things", "Friends", "The Office",
+        "Dark", "The Crown", "House of Cards", "Sherlock", "Lost",
+        "Der König der Löwen", "Findet Nemo", "Toy Story", "Shrek", "Frozen",
+        "Indiana Jones", "James Bond", "Rocky", "Top Gun", "Gladiator",
+    ]),
+    ("Sport", [
+        "Fußball", "Tennis", "Basketball", "Skifahren", "Schwimmen",
+        "Volleyball", "Handball", "Eishockey", "Baseball", "Golf",
+        "Boxen", "Judo", "Reiten", "Klettern", "Surfen",
+        "Snowboarden", "Rudern", "Marathon", "Hochsprung", "Speerwurf",
+        "Yoga", "Pilates", "Tischtennis", "Badminton", "Squash",
+        "Curling", "Bogenschießen", "Fechten", "Rugby", "Bowling",
+    ]),
+    ("Musikinstrumente", [
+        "Klavier", "Gitarre", "Geige", "Schlagzeug", "Saxophon",
+        "Trompete", "Flöte", "Harfe", "Cello", "Klarinette",
+        "Akkordeon", "Mundharmonika", "Bass", "Banjo", "Mandoline",
+        "Posaune", "Tuba", "Triangel", "Gong", "Xylophon",
+        "Marimba", "Dudelsack", "Synthesizer", "Bratsche", "Kontrabass",
+        "Ukulele", "Pauke", "Tamburin", "Maracas", "Cajón",
+    ]),
+    ("Fahrzeuge", [
+        "Auto", "Fahrrad", "Motorrad", "Bus", "Zug",
+        "Flugzeug", "Schiff", "U-Boot", "Hubschrauber", "Traktor",
+        "LKW", "Roller", "Skateboard", "Inlineskates", "Segelboot",
+        "Kanu", "Kajak", "Heißluftballon", "Rakete", "Straßenbahn",
+        "U-Bahn", "Lokomotive", "Pferdekutsche", "Schlitten", "Schneemobil",
+        "Quad", "Bagger", "Müllwagen", "Krankenwagen", "Taxi",
+    ]),
+    ("Werkzeuge", [
+        "Hammer", "Schraubenzieher", "Säge", "Bohrmaschine", "Zange",
+        "Schraubenschlüssel", "Wasserwaage", "Maßband", "Schaufel", "Spaten",
+        "Rechen", "Hacke", "Schubkarre", "Leiter", "Pinsel",
+        "Rolle", "Spachtel", "Cuttermesser", "Schere", "Klebepistole",
+        "Akkuschrauber", "Stichsäge", "Kreissäge", "Hobel", "Feile",
+        "Meißel", "Schraubstock", "Lötkolben", "Multimeter", "Taschenlampe",
+    ]),
+    ("Kleidung", [
+        "T-Shirt", "Hose", "Pullover", "Jacke", "Mantel",
+        "Kleid", "Rock", "Schal", "Mütze", "Handschuhe",
+        "Socken", "Schuhe", "Stiefel", "Sandalen", "Hemd",
+        "Krawatte", "Anzug", "Bademantel", "Pyjama", "Bikini",
+        "Badehose", "Jeans", "Trainingsanzug", "Hut", "Cap",
+        "Gürtel", "Tasche", "Rucksack", "Geldbörse", "Sonnenbrille",
+    ]),
+    ("Möbel", [
+        "Tisch", "Stuhl", "Sofa", "Bett", "Schrank",
+        "Regal", "Kommode", "Sessel", "Hocker", "Bank",
+        "Schreibtisch", "Couchtisch", "Esstisch", "Kleiderschrank", "Bücherregal",
+        "Nachttisch", "Spiegel", "Garderobe", "Vitrine", "Sideboard",
+        "Schaukelstuhl", "Liegestuhl", "Hängematte", "Kinderbett", "Hochstuhl",
+        "Etagenbett", "Sekretär", "Truhe", "Couch", "Bartisch",
+    ]),
+    ("Obst", [
+        "Apfel", "Banane", "Orange", "Erdbeere", "Kirsche",
+        "Birne", "Zitrone", "Wassermelone", "Ananas", "Mango",
+        "Kiwi", "Pfirsich", "Aprikose", "Pflaume", "Traube",
+        "Himbeere", "Heidelbeere", "Brombeere", "Granatapfel", "Feige",
+        "Dattel", "Kokosnuss", "Papaya", "Maracuja", "Litschi",
+        "Mandarine", "Grapefruit", "Stachelbeere", "Quitte", "Kaki",
+    ]),
+    ("Gemüse", [
+        "Karotte", "Tomate", "Gurke", "Salat", "Paprika",
+        "Zwiebel", "Knoblauch", "Kartoffel", "Brokkoli", "Karfiol",
+        "Spinat", "Kürbis", "Zucchini", "Aubergine", "Mais",
+        "Erbsen", "Bohnen", "Lauch", "Sellerie", "Rote Bete",
+        "Radieschen", "Rettich", "Pastinake", "Spargel", "Artischocke",
+        "Fenchel", "Mangold", "Rucola", "Chinakohl", "Süßkartoffel",
+    ]),
+    ("Getränke", [
+        "Wasser", "Kaffee", "Tee", "Milch", "Bier",
+        "Wein", "Sekt", "Cola", "Limonade", "Saft",
+        "Smoothie", "Cocktail", "Whisky", "Wodka", "Gin",
+        "Rum", "Tequila", "Champagner", "Cidre", "Likör",
+        "Espresso", "Cappuccino", "Latte Macchiato", "Heiße Schokolade", "Eistee",
+        "Energy Drink", "Mineralwasser", "Apfelsaft", "Orangensaft", "Mezcal",
+    ]),
+    ("Körperteile", [
+        "Kopf", "Arm", "Bein", "Hand", "Fuß",
+        "Auge", "Ohr", "Nase", "Mund", "Zahn",
+        "Finger", "Zehe", "Knie", "Ellbogen", "Schulter",
+        "Rücken", "Bauch", "Brust", "Hals", "Kinn",
+        "Stirn", "Wange", "Lippe", "Zunge", "Hüfte",
+        "Knöchel", "Handgelenk", "Augenbraue", "Wimper", "Nacken",
+    ]),
+    ("Haushaltsgeräte", [
+        "Kühlschrank", "Waschmaschine", "Geschirrspüler", "Mikrowelle", "Backofen",
+        "Herd", "Toaster", "Kaffeemaschine", "Wasserkocher", "Mixer",
+        "Staubsauger", "Bügeleisen", "Fernseher", "Föhn", "Rasierer",
+        "Trockner", "Klimaanlage", "Ventilator", "Heizung", "Thermomix",
+        "Stabmixer", "Eismaschine", "Brotbackautomat", "Reiskocher", "Friteuse",
+        "Dampfreiniger", "Heizdecke", "Luftbefeuchter", "Wäscheständer", "Nähmaschine",
+    ]),
+    ("Wetter & Natur", [
+        "Regen", "Schnee", "Sonne", "Wolke", "Blitz",
+        "Donner", "Sturm", "Hagel", "Nebel", "Regenbogen",
+        "Berg", "Tal", "Fluss", "See", "Meer",
+        "Wald", "Wüste", "Insel", "Vulkan", "Wasserfall",
+        "Gletscher", "Höhle", "Strand", "Klippe", "Sumpf",
+        "Lawine", "Erdbeben", "Tornado", "Tsunami", "Hurrikan",
+    ]),
+    ("Schule & Büro", [
+        "Stift", "Bleistift", "Radiergummi", "Lineal", "Heft",
+        "Buch", "Tafel", "Kreide", "Spitzer", "Schultasche",
+        "Mäppchen", "Filzstift", "Textmarker", "Klebstoff", "Tacker",
+        "Locher", "Ordner", "Briefumschlag", "Notizbuch", "Taschenrechner",
+        "Computer", "Drucker", "Scanner", "Whiteboard", "Beamer",
+        "Pinnwand", "Kalender", "Globus", "Atlas", "Lehrbuch",
+    ]),
+    ("Spielzeug & Spiele", [
+        "Lego", "Puppe", "Teddybär", "Puzzle", "Brettspiel",
+        "Schach", "Würfel", "Skateboard", "Trampolin", "Kreisel",
+        "Yo-Yo", "Wasserpistole", "Drachen", "Bauklötze", "Murmeln",
+        "Karten", "Memory", "Monopoly", "Scrabble", "Mensch ärgere dich nicht",
+        "Frisbee", "Roller", "Hüpfball", "Zauberwürfel", "Modelleisenbahn",
+        "Spielfigur", "Springseil", "Federball", "Sandkasten", "Schaukel",
+    ]),
+    ("Märchen & Fantasie", [
+        "Drache", "Einhorn", "Hexe", "Zauberer", "Prinzessin",
+        "Ritter", "Vampir", "Werwolf", "Zombie", "Geist",
+        "Elf", "Zwerg", "Troll", "Riese", "Fee",
+        "Meerjungfrau", "Phönix", "Greif", "Zentaur", "Kobold",
+        "Yeti", "Goblin", "Magier", "Orakel", "Pegasus",
+        "Sphinx", "Basilisk", "Minotaurus", "Frosch König", "Schneewittchen",
+    ]),
+]
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        "impostor_categories",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("name", sa.String(length=100), nullable=False),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column("sort_order", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("name"),
+    )
+    op.create_index(
+        "ix_impostor_categories_name",
+        "impostor_categories",
+        ["name"],
+        unique=True,
+    )
+    op.create_index(
+        "ix_impostor_categories_id",
+        "impostor_categories",
+        ["id"],
+    )
+
+    op.create_table(
+        "impostor_words",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("category_id", sa.Integer(), nullable=False),
+        sa.Column("word", sa.String(length=100), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.ForeignKeyConstraint(
+            ["category_id"],
+            ["impostor_categories.id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("category_id", "word", name="uq_impostor_word_per_category"),
+    )
+    op.create_index(
+        "ix_impostor_words_id",
+        "impostor_words",
+        ["id"],
+    )
+    op.create_index(
+        "ix_impostor_words_category_id",
+        "impostor_words",
+        ["category_id"],
+    )
+
+    # ---- Seed-Daten ----
+    cat_table = sa.table(
+        "impostor_categories",
+        sa.column("id", sa.Integer),
+        sa.column("name", sa.String),
+        sa.column("is_active", sa.Boolean),
+        sa.column("sort_order", sa.Integer),
+    )
+    word_table = sa.table(
+        "impostor_words",
+        sa.column("category_id", sa.Integer),
+        sa.column("word", sa.String),
+    )
+
+    bind = op.get_bind()
+
+    for sort_idx, (cat_name, words) in enumerate(SEED_DATA):
+        result = bind.execute(
+            sa.insert(cat_table)
+            .values(name=cat_name, is_active=True, sort_order=sort_idx)
+            .returning(cat_table.c.id)
+        )
+        cat_id = result.scalar_one()
+        bind.execute(
+            sa.insert(word_table),
+            [{"category_id": cat_id, "word": w} for w in words],
+        )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index("ix_impostor_words_category_id", table_name="impostor_words")
+    op.drop_index("ix_impostor_words_id", table_name="impostor_words")
+    op.drop_table("impostor_words")
+    op.drop_index("ix_impostor_categories_id", table_name="impostor_categories")
+    op.drop_index("ix_impostor_categories_name", table_name="impostor_categories")
+    op.drop_table("impostor_categories")

--- a/backend/main.py
+++ b/backend/main.py
@@ -6,7 +6,7 @@ from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware
 from database import Base, engine
 import models
-from routers import auth, blog, shopping, admin, recipes, tags, seasonal, settings
+from routers import auth, blog, shopping, admin, recipes, tags, seasonal, settings, impostor
 from rate_limit import limiter
 import os
 import logging
@@ -37,6 +37,7 @@ app.include_router(recipes.router)
 app.include_router(tags.router)
 app.include_router(seasonal.router)
 app.include_router(settings.router)
+app.include_router(impostor.router)
 
 # Test-Only-Endpoints: NUR registrieren wenn ENVIRONMENT=test
 if os.getenv("ENVIRONMENT") == "test":

--- a/backend/models.py
+++ b/backend/models.py
@@ -248,3 +248,42 @@ class SiteSetting(Base):
         onupdate=func.now(),
         nullable=False,
     )
+
+
+# ==================== Impostor-Spiel ====================
+
+class ImpostorCategory(Base):
+    __tablename__ = "impostor_categories"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String(100), nullable=False, unique=True, index=True)
+    is_active = Column(Boolean, default=True, nullable=False)
+    sort_order = Column(Integer, default=0, nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+
+    words = relationship(
+        "ImpostorWord",
+        back_populates="category",
+        cascade="all, delete-orphan",
+        order_by="ImpostorWord.word",
+    )
+
+
+class ImpostorWord(Base):
+    __tablename__ = "impostor_words"
+
+    id = Column(Integer, primary_key=True, index=True)
+    category_id = Column(
+        Integer,
+        ForeignKey("impostor_categories.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    word = Column(String(100), nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+
+    __table_args__ = (
+        UniqueConstraint("category_id", "word", name="uq_impostor_word_per_category"),
+    )
+
+    category = relationship("ImpostorCategory", back_populates="words")

--- a/backend/routers/impostor.py
+++ b/backend/routers/impostor.py
@@ -1,0 +1,352 @@
+"""
+Impostor-Spiel API.
+
+Public:
+- GET  /impostor/categories                 — Liste aktiver Kategorien (für Setup)
+- POST /impostor/random                     — Ein zufälliges Wort aus den gewählten Kategorien
+
+Admin:
+- GET    /impostor/admin/categories         — Alle Kategorien (inkl. inaktiver)
+- POST   /impostor/admin/categories         — Neue Kategorie
+- PATCH  /impostor/admin/categories/{id}    — Kategorie umbenennen / (de-)aktivieren
+- DELETE /impostor/admin/categories/{id}    — Kategorie + Wörter löschen
+- GET    /impostor/admin/categories/{id}/words — Wörter einer Kategorie
+- POST   /impostor/admin/categories/{id}/words — Ein oder mehrere Wörter hinzufügen
+- DELETE /impostor/admin/words/{id}         — Einzelnes Wort löschen
+"""
+
+from datetime import datetime
+from typing import Optional
+import random
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field, field_validator
+from sqlalchemy.orm import Session
+
+from database import get_db
+from auth import require_admin
+import models
+
+router = APIRouter(prefix="/impostor", tags=["impostor"])
+
+
+# ---------- Pydantic Schemas ----------
+
+class CategoryPublic(BaseModel):
+    """Öffentliche Sicht: nur das Nötigste fürs Setup."""
+    id: int
+    name: str
+    word_count: int
+
+    model_config = {"from_attributes": True}
+
+
+class CategoryAdmin(BaseModel):
+    id: int
+    name: str
+    is_active: bool
+    sort_order: int
+    word_count: int
+    created_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class CategoryCreate(BaseModel):
+    name: str = Field(..., min_length=1, max_length=100)
+    is_active: bool = True
+    sort_order: int = 0
+
+    @field_validator("name")
+    @classmethod
+    def strip_name(cls, v: str) -> str:
+        v = v.strip()
+        if not v:
+            raise ValueError("Name darf nicht leer sein")
+        return v
+
+
+class CategoryUpdate(BaseModel):
+    name: Optional[str] = Field(None, min_length=1, max_length=100)
+    is_active: Optional[bool] = None
+    sort_order: Optional[int] = None
+
+    @field_validator("name")
+    @classmethod
+    def strip_name(cls, v):
+        if v is None:
+            return v
+        v = v.strip()
+        if not v:
+            raise ValueError("Name darf nicht leer sein")
+        return v
+
+
+class WordRead(BaseModel):
+    id: int
+    word: str
+
+    model_config = {"from_attributes": True}
+
+
+class WordsCreate(BaseModel):
+    """Akzeptiert ein Wort oder mehrere (Bulk)."""
+    words: list[str] = Field(..., min_length=1, max_length=200)
+
+    @field_validator("words")
+    @classmethod
+    def clean_words(cls, v: list[str]) -> list[str]:
+        cleaned = []
+        seen = set()
+        for w in v:
+            w = w.strip()
+            if not w:
+                continue
+            if len(w) > 100:
+                raise ValueError(f"Wort zu lang (max 100 Zeichen): {w[:30]}…")
+            key = w.lower()
+            if key in seen:
+                continue
+            seen.add(key)
+            cleaned.append(w)
+        if not cleaned:
+            raise ValueError("Mindestens ein gültiges Wort erforderlich")
+        return cleaned
+
+
+class RandomRequest(BaseModel):
+    category_ids: list[int] = Field(..., min_length=1, max_length=50)
+
+
+class RandomResponse(BaseModel):
+    word: str
+    category_id: int
+    category_name: str
+
+
+# ---------- Helpers ----------
+
+def _category_to_admin(cat: models.ImpostorCategory) -> CategoryAdmin:
+    return CategoryAdmin(
+        id=cat.id,
+        name=cat.name,
+        is_active=cat.is_active,
+        sort_order=cat.sort_order,
+        word_count=len(cat.words),
+        created_at=cat.created_at,
+    )
+
+
+def _category_to_public(cat: models.ImpostorCategory) -> CategoryPublic:
+    return CategoryPublic(id=cat.id, name=cat.name, word_count=len(cat.words))
+
+
+# ---------- Public Endpoints ----------
+
+@router.get("/categories", response_model=list[CategoryPublic])
+def list_active_categories(db: Session = Depends(get_db)):
+    """Aktive Kategorien mit mindestens einem Wort, für den Setup-Screen."""
+    cats = (
+        db.query(models.ImpostorCategory)
+        .filter(models.ImpostorCategory.is_active.is_(True))
+        .order_by(models.ImpostorCategory.sort_order, models.ImpostorCategory.name)
+        .all()
+    )
+    return [_category_to_public(c) for c in cats if len(c.words) > 0]
+
+
+@router.post("/random", response_model=RandomResponse)
+def random_word(payload: RandomRequest, db: Session = Depends(get_db)):
+    """
+    Liefert genau ein zufälliges Wort aus einer der gewählten (und aktiven)
+    Kategorien. Strategie: Zuerst zufällig eine Kategorie wählen (gewichtet
+    nach Wortanzahl, damit kleine Kategorien nicht überrepräsentiert werden),
+    dann ein zufälliges Wort daraus.
+    """
+    cats = (
+        db.query(models.ImpostorCategory)
+        .filter(
+            models.ImpostorCategory.id.in_(payload.category_ids),
+            models.ImpostorCategory.is_active.is_(True),
+        )
+        .all()
+    )
+    if not cats:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Keine gültige Kategorie ausgewählt",
+        )
+
+    weighted = [(c, len(c.words)) for c in cats if len(c.words) > 0]
+    if not weighted:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Ausgewählte Kategorien enthalten keine Wörter",
+        )
+
+    cats_only, weights = zip(*weighted)
+    chosen_cat = random.choices(cats_only, weights=weights, k=1)[0]
+    chosen_word = random.choice(chosen_cat.words)
+
+    return RandomResponse(
+        word=chosen_word.word,
+        category_id=chosen_cat.id,
+        category_name=chosen_cat.name,
+    )
+
+
+# ---------- Admin: Categories ----------
+
+@router.get("/admin/categories", response_model=list[CategoryAdmin])
+def admin_list_categories(
+    db: Session = Depends(get_db),
+    user: models.User = Depends(require_admin),
+):
+    cats = (
+        db.query(models.ImpostorCategory)
+        .order_by(models.ImpostorCategory.sort_order, models.ImpostorCategory.name)
+        .all()
+    )
+    return [_category_to_admin(c) for c in cats]
+
+
+@router.post("/admin/categories", response_model=CategoryAdmin, status_code=status.HTTP_201_CREATED)
+def admin_create_category(
+    payload: CategoryCreate,
+    db: Session = Depends(get_db),
+    user: models.User = Depends(require_admin),
+):
+    existing = (
+        db.query(models.ImpostorCategory)
+        .filter(models.ImpostorCategory.name == payload.name)
+        .first()
+    )
+    if existing:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Kategorie mit diesem Namen existiert bereits",
+        )
+
+    cat = models.ImpostorCategory(
+        name=payload.name,
+        is_active=payload.is_active,
+        sort_order=payload.sort_order,
+    )
+    db.add(cat)
+    db.commit()
+    db.refresh(cat)
+    return _category_to_admin(cat)
+
+
+@router.patch("/admin/categories/{category_id}", response_model=CategoryAdmin)
+def admin_update_category(
+    category_id: int,
+    payload: CategoryUpdate,
+    db: Session = Depends(get_db),
+    user: models.User = Depends(require_admin),
+):
+    cat = db.get(models.ImpostorCategory, category_id)
+    if not cat:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Kategorie nicht gefunden")
+
+    if payload.name is not None and payload.name != cat.name:
+        clash = (
+            db.query(models.ImpostorCategory)
+            .filter(
+                models.ImpostorCategory.name == payload.name,
+                models.ImpostorCategory.id != category_id,
+            )
+            .first()
+        )
+        if clash:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Kategorie mit diesem Namen existiert bereits",
+            )
+        cat.name = payload.name
+
+    if payload.is_active is not None:
+        cat.is_active = payload.is_active
+    if payload.sort_order is not None:
+        cat.sort_order = payload.sort_order
+
+    db.commit()
+    db.refresh(cat)
+    return _category_to_admin(cat)
+
+
+@router.delete("/admin/categories/{category_id}", status_code=status.HTTP_204_NO_CONTENT)
+def admin_delete_category(
+    category_id: int,
+    db: Session = Depends(get_db),
+    user: models.User = Depends(require_admin),
+):
+    cat = db.get(models.ImpostorCategory, category_id)
+    if not cat:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Kategorie nicht gefunden")
+    db.delete(cat)
+    db.commit()
+
+
+# ---------- Admin: Words ----------
+
+@router.get("/admin/categories/{category_id}/words", response_model=list[WordRead])
+def admin_list_words(
+    category_id: int,
+    db: Session = Depends(get_db),
+    user: models.User = Depends(require_admin),
+):
+    cat = db.get(models.ImpostorCategory, category_id)
+    if not cat:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Kategorie nicht gefunden")
+    return [WordRead.model_validate(w) for w in cat.words]
+
+
+@router.post(
+    "/admin/categories/{category_id}/words",
+    response_model=list[WordRead],
+    status_code=status.HTTP_201_CREATED,
+)
+def admin_create_words(
+    category_id: int,
+    payload: WordsCreate,
+    db: Session = Depends(get_db),
+    user: models.User = Depends(require_admin),
+):
+    cat = db.get(models.ImpostorCategory, category_id)
+    if not cat:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Kategorie nicht gefunden")
+
+    existing_lower = {w.word.lower() for w in cat.words}
+    new_words: list[models.ImpostorWord] = []
+    for w in payload.words:
+        if w.lower() in existing_lower:
+            continue
+        word_obj = models.ImpostorWord(category_id=category_id, word=w)
+        db.add(word_obj)
+        new_words.append(word_obj)
+        existing_lower.add(w.lower())
+
+    if not new_words:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Alle übergebenen Wörter existieren bereits in dieser Kategorie",
+        )
+
+    db.commit()
+    for w in new_words:
+        db.refresh(w)
+    return [WordRead.model_validate(w) for w in new_words]
+
+
+@router.delete("/admin/words/{word_id}", status_code=status.HTTP_204_NO_CONTENT)
+def admin_delete_word(
+    word_id: int,
+    db: Session = Depends(get_db),
+    user: models.User = Depends(require_admin),
+):
+    word = db.get(models.ImpostorWord, word_id)
+    if not word:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Wort nicht gefunden")
+    db.delete(word)
+    db.commit()

--- a/backend/tests/test_impostor.py
+++ b/backend/tests/test_impostor.py
@@ -1,0 +1,335 @@
+"""Tests für den Impostor-Router."""
+
+
+# ---------- Helpers ----------
+
+def _create_category(client, admin_headers, name="Testkategorie", is_active=True, sort_order=0):
+    res = client.post(
+        "/impostor/admin/categories",
+        json={"name": name, "is_active": is_active, "sort_order": sort_order},
+        headers=admin_headers,
+    )
+    assert res.status_code == 201, res.text
+    return res.json()
+
+
+def _add_words(client, admin_headers, cat_id, words):
+    res = client.post(
+        f"/impostor/admin/categories/{cat_id}/words",
+        json={"words": words},
+        headers=admin_headers,
+    )
+    assert res.status_code == 201, res.text
+    return res.json()
+
+
+# ---------- Public Endpoints ----------
+
+class TestPublicEndpoints:
+    def test_list_categories_empty(self, client):
+        res = client.get("/impostor/categories")
+        assert res.status_code == 200
+        assert res.json() == []
+
+    def test_list_categories_excludes_inactive(self, client, admin_headers):
+        active = _create_category(client, admin_headers, name="Aktiv")
+        inactive = _create_category(client, admin_headers, name="Inaktiv", is_active=False)
+        _add_words(client, admin_headers, active["id"], ["Wort1"])
+        _add_words(client, admin_headers, inactive["id"], ["Wort2"])
+
+        res = client.get("/impostor/categories")
+        assert res.status_code == 200
+        names = [c["name"] for c in res.json()]
+        assert "Aktiv" in names
+        assert "Inaktiv" not in names
+
+    def test_list_categories_excludes_empty(self, client, admin_headers):
+        """Kategorien ohne Wörter dürfen nicht im Setup auftauchen."""
+        with_words = _create_category(client, admin_headers, name="MitWoertern")
+        _create_category(client, admin_headers, name="OhneWoerter")
+        _add_words(client, admin_headers, with_words["id"], ["Foo"])
+
+        res = client.get("/impostor/categories")
+        names = [c["name"] for c in res.json()]
+        assert "MitWoertern" in names
+        assert "OhneWoerter" not in names
+
+    def test_list_categories_word_count(self, client, admin_headers):
+        cat = _create_category(client, admin_headers, name="Count")
+        _add_words(client, admin_headers, cat["id"], ["A", "B", "C"])
+
+        res = client.get("/impostor/categories")
+        data = [c for c in res.json() if c["name"] == "Count"][0]
+        assert data["word_count"] == 3
+
+    def test_list_categories_no_auth_required(self, client, admin_headers):
+        cat = _create_category(client, admin_headers, name="Public")
+        _add_words(client, admin_headers, cat["id"], ["X"])
+        # Ohne Auth-Header
+        res = client.get("/impostor/categories")
+        assert res.status_code == 200
+
+    def test_random_word_returns_from_chosen_category(self, client, admin_headers):
+        cat = _create_category(client, admin_headers, name="OnlyOne")
+        _add_words(client, admin_headers, cat["id"], ["Hammer", "Saege"])
+
+        res = client.post("/impostor/random", json={"category_ids": [cat["id"]]})
+        assert res.status_code == 200
+        data = res.json()
+        assert data["category_id"] == cat["id"]
+        assert data["category_name"] == "OnlyOne"
+        assert data["word"] in ["Hammer", "Saege"]
+
+    def test_random_word_no_auth_required(self, client, admin_headers):
+        cat = _create_category(client, admin_headers, name="Public2")
+        _add_words(client, admin_headers, cat["id"], ["X"])
+        res = client.post("/impostor/random", json={"category_ids": [cat["id"]]})
+        assert res.status_code == 200
+
+    def test_random_word_404_for_invalid_category(self, client):
+        res = client.post("/impostor/random", json={"category_ids": [99999]})
+        assert res.status_code == 404
+
+    def test_random_word_404_for_inactive_category(self, client, admin_headers):
+        cat = _create_category(client, admin_headers, name="Inaktiv2", is_active=False)
+        _add_words(client, admin_headers, cat["id"], ["X"])
+        res = client.post("/impostor/random", json={"category_ids": [cat["id"]]})
+        assert res.status_code == 404
+
+    def test_random_word_404_when_categories_have_no_words(self, client, admin_headers):
+        cat = _create_category(client, admin_headers, name="Leer")
+        res = client.post("/impostor/random", json={"category_ids": [cat["id"]]})
+        assert res.status_code == 404
+
+    def test_random_word_validates_payload(self, client):
+        res = client.post("/impostor/random", json={"category_ids": []})
+        assert res.status_code == 422
+
+
+# ---------- Admin: Categories ----------
+
+class TestAdminCategories:
+    def test_list_requires_admin(self, client, auth_headers):
+        res = client.get("/impostor/admin/categories", headers=auth_headers)
+        assert res.status_code == 403
+
+    def test_list_unauth(self, client):
+        res = client.get("/impostor/admin/categories")
+        assert res.status_code == 401
+
+    def test_create_requires_admin(self, client, auth_headers):
+        res = client.post(
+            "/impostor/admin/categories",
+            json={"name": "Foo"},
+            headers=auth_headers,
+        )
+        assert res.status_code == 403
+
+    def test_create_and_list(self, client, admin_headers):
+        _create_category(client, admin_headers, name="Eins")
+        _create_category(client, admin_headers, name="Zwei", is_active=False)
+
+        res = client.get("/impostor/admin/categories", headers=admin_headers)
+        assert res.status_code == 200
+        names = [c["name"] for c in res.json()]
+        assert "Eins" in names
+        assert "Zwei" in names
+
+    def test_create_duplicate_name_409(self, client, admin_headers):
+        _create_category(client, admin_headers, name="Dup")
+        res = client.post(
+            "/impostor/admin/categories",
+            json={"name": "Dup"},
+            headers=admin_headers,
+        )
+        assert res.status_code == 409
+
+    def test_create_strips_whitespace(self, client, admin_headers):
+        cat = _create_category(client, admin_headers, name="  Trimmed  ")
+        assert cat["name"] == "Trimmed"
+
+    def test_create_empty_name_422(self, client, admin_headers):
+        res = client.post(
+            "/impostor/admin/categories",
+            json={"name": "   "},
+            headers=admin_headers,
+        )
+        assert res.status_code == 422
+
+    def test_update_rename(self, client, admin_headers):
+        cat = _create_category(client, admin_headers, name="Alt")
+        res = client.patch(
+            f"/impostor/admin/categories/{cat['id']}",
+            json={"name": "Neu"},
+            headers=admin_headers,
+        )
+        assert res.status_code == 200
+        assert res.json()["name"] == "Neu"
+
+    def test_update_toggle_active(self, client, admin_headers):
+        cat = _create_category(client, admin_headers, name="Toggle")
+        res = client.patch(
+            f"/impostor/admin/categories/{cat['id']}",
+            json={"is_active": False},
+            headers=admin_headers,
+        )
+        assert res.status_code == 200
+        assert res.json()["is_active"] is False
+
+    def test_update_rename_clash_409(self, client, admin_headers):
+        _create_category(client, admin_headers, name="A")
+        b = _create_category(client, admin_headers, name="B")
+        res = client.patch(
+            f"/impostor/admin/categories/{b['id']}",
+            json={"name": "A"},
+            headers=admin_headers,
+        )
+        assert res.status_code == 409
+
+    def test_update_404(self, client, admin_headers):
+        res = client.patch(
+            "/impostor/admin/categories/99999",
+            json={"name": "X"},
+            headers=admin_headers,
+        )
+        assert res.status_code == 404
+
+    def test_delete_cascades_words(self, client, admin_headers):
+        cat = _create_category(client, admin_headers, name="ToDelete")
+        _add_words(client, admin_headers, cat["id"], ["W1", "W2"])
+
+        res = client.delete(
+            f"/impostor/admin/categories/{cat['id']}",
+            headers=admin_headers,
+        )
+        assert res.status_code == 204
+
+        # Kategorie existiert nicht mehr → 404 beim Word-List
+        res = client.get(
+            f"/impostor/admin/categories/{cat['id']}/words",
+            headers=admin_headers,
+        )
+        assert res.status_code == 404
+
+    def test_delete_404(self, client, admin_headers):
+        res = client.delete(
+            "/impostor/admin/categories/99999",
+            headers=admin_headers,
+        )
+        assert res.status_code == 404
+
+
+# ---------- Admin: Words ----------
+
+class TestAdminWords:
+    def test_add_words_bulk(self, client, admin_headers):
+        cat = _create_category(client, admin_headers, name="Bulk")
+        res = client.post(
+            f"/impostor/admin/categories/{cat['id']}/words",
+            json={"words": ["A", "B", "C"]},
+            headers=admin_headers,
+        )
+        assert res.status_code == 201
+        assert len(res.json()) == 3
+
+    def test_add_words_dedupes_within_payload(self, client, admin_headers):
+        cat = _create_category(client, admin_headers, name="Dedup")
+        res = client.post(
+            f"/impostor/admin/categories/{cat['id']}/words",
+            json={"words": ["A", "a", "A "]},
+            headers=admin_headers,
+        )
+        assert res.status_code == 201
+        assert len(res.json()) == 1
+
+    def test_add_words_skips_existing(self, client, admin_headers):
+        cat = _create_category(client, admin_headers, name="Skip")
+        _add_words(client, admin_headers, cat["id"], ["A", "B"])
+        # Jetzt nochmal A + neues C
+        res = client.post(
+            f"/impostor/admin/categories/{cat['id']}/words",
+            json={"words": ["A", "C"]},
+            headers=admin_headers,
+        )
+        assert res.status_code == 201
+        words = [w["word"] for w in res.json()]
+        assert words == ["C"]
+
+    def test_add_words_all_existing_409(self, client, admin_headers):
+        cat = _create_category(client, admin_headers, name="AllExist")
+        _add_words(client, admin_headers, cat["id"], ["A"])
+        res = client.post(
+            f"/impostor/admin/categories/{cat['id']}/words",
+            json={"words": ["A", "a"]},
+            headers=admin_headers,
+        )
+        assert res.status_code == 409
+
+    def test_add_words_empty_payload_422(self, client, admin_headers):
+        cat = _create_category(client, admin_headers, name="Empty")
+        res = client.post(
+            f"/impostor/admin/categories/{cat['id']}/words",
+            json={"words": []},
+            headers=admin_headers,
+        )
+        assert res.status_code == 422
+
+    def test_add_words_only_whitespace_422(self, client, admin_headers):
+        cat = _create_category(client, admin_headers, name="Whitespace")
+        res = client.post(
+            f"/impostor/admin/categories/{cat['id']}/words",
+            json={"words": ["  ", ""]},
+            headers=admin_headers,
+        )
+        assert res.status_code == 422
+
+    def test_add_words_404_for_unknown_category(self, client, admin_headers):
+        res = client.post(
+            "/impostor/admin/categories/99999/words",
+            json={"words": ["A"]},
+            headers=admin_headers,
+        )
+        assert res.status_code == 404
+
+    def test_list_words(self, client, admin_headers):
+        cat = _create_category(client, admin_headers, name="ListWords")
+        _add_words(client, admin_headers, cat["id"], ["B", "A", "C"])
+        res = client.get(
+            f"/impostor/admin/categories/{cat['id']}/words",
+            headers=admin_headers,
+        )
+        assert res.status_code == 200
+        # Order ist alphabetisch (siehe Model: order_by=ImpostorWord.word)
+        assert [w["word"] for w in res.json()] == ["A", "B", "C"]
+
+    def test_delete_word(self, client, admin_headers):
+        cat = _create_category(client, admin_headers, name="DelWord")
+        words = _add_words(client, admin_headers, cat["id"], ["A", "B"])
+        res = client.delete(
+            f"/impostor/admin/words/{words[0]['id']}",
+            headers=admin_headers,
+        )
+        assert res.status_code == 204
+
+        res = client.get(
+            f"/impostor/admin/categories/{cat['id']}/words",
+            headers=admin_headers,
+        )
+        remaining = [w["word"] for w in res.json()]
+        assert words[0]["word"] not in remaining
+
+    def test_delete_word_404(self, client, admin_headers):
+        res = client.delete(
+            "/impostor/admin/words/99999",
+            headers=admin_headers,
+        )
+        assert res.status_code == 404
+
+    def test_words_admin_only(self, client, auth_headers, admin_headers):
+        cat = _create_category(client, admin_headers, name="MemberCheck")
+        res = client.post(
+            f"/impostor/admin/categories/{cat['id']}/words",
+            json={"words": ["X"]},
+            headers=auth_headers,
+        )
+        assert res.status_code == 403

--- a/e2e/tests/impostor.spec.ts
+++ b/e2e/tests/impostor.spec.ts
@@ -1,0 +1,147 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Impostor-Spiel (öffentlich, ohne Login)', () => {
+  test('Setup-Seite ist ohne Login erreichbar und lädt Kategorien', async ({ page }) => {
+    await page.goto('/impostor');
+
+    // Heading sichtbar
+    await expect(page.getByRole('heading', { name: 'Impostor' })).toBeVisible();
+
+    // Default-Spieleranzahl ist 4
+    await expect(page.getByTestId('player-count')).toHaveText('4');
+
+    // Kategorien sind da (mind. eine — die Seed-Migration legt 20 an,
+    // aber wir wollen nicht hartcodieren falls jemand welche deaktiviert hat)
+    const startBtn = page.getByTestId('start-button');
+    await expect(startBtn).toBeVisible();
+  });
+
+  test('Validierung: Start ohne Spielernamen schlägt fehl', async ({ page }) => {
+    await page.goto('/impostor');
+    await page.getByTestId('start-button').click();
+    await expect(page.getByTestId('start-error')).toContainText(/spielernamen/i);
+  });
+
+  test('Validierung: Doppelte Spielernamen werden abgelehnt', async ({ page }) => {
+    await page.goto('/impostor');
+
+    // 4 Namen, davon 2 gleich
+    await page.getByTestId('player-name-0').fill('Alice');
+    await page.getByTestId('player-name-1').fill('Bob');
+    await page.getByTestId('player-name-2').fill('alice'); // case-insensitive Duplikat
+    await page.getByTestId('player-name-3').fill('Dave');
+
+    await page.getByTestId('start-button').click();
+    await expect(page.getByTestId('start-error')).toContainText(/eindeutig/i);
+  });
+
+  test('Spieleranzahl-Buttons funktionieren', async ({ page }) => {
+    await page.goto('/impostor');
+
+    const count = page.getByTestId('player-count');
+    await expect(count).toHaveText('4');
+
+    // +1
+    await page.getByRole('button', { name: 'Spieler hinzufügen' }).click();
+    await expect(count).toHaveText('5');
+    await expect(page.getByTestId('player-name-4')).toBeVisible();
+
+    // -2
+    await page.getByRole('button', { name: 'Spieler entfernen' }).click();
+    await page.getByRole('button', { name: 'Spieler entfernen' }).click();
+    await expect(count).toHaveText('3');
+  });
+
+  test('Vollständiger Spielablauf: Setup → Reveal → Auflösung', async ({ page }) => {
+    await page.goto('/impostor');
+
+    // Auf 3 Spieler reduzieren (Default ist 4)
+    await page.getByRole('button', { name: 'Spieler entfernen' }).click();
+    await expect(page.getByTestId('player-count')).toHaveText('3');
+
+    // Namen eingeben
+    await page.getByTestId('player-name-0').fill('Alice');
+    await page.getByTestId('player-name-1').fill('Bob');
+    await page.getByTestId('player-name-2').fill('Carol');
+
+    // Themen-Hinweis für Imposter aktivieren — testet auch diesen Code-Pfad
+    await page.getByTestId('show-category-to-impostor').check();
+
+    // Spiel starten
+    await page.getByTestId('start-button').click();
+
+    // ---------- Reveal-Phase ----------
+
+    // Erster Spieler ist Alice
+    await expect(page.getByTestId('current-player')).toHaveText('Alice');
+
+    // Karte verdeckt → "Halten zum Anzeigen" sichtbar
+    const card = page.getByTestId('reveal-card');
+    await expect(card).toHaveAttribute('data-revealing', 'false');
+    await expect(card).toContainText('Halten zum Anzeigen');
+
+    // Tap-and-Hold simulieren
+    await card.dispatchEvent('pointerdown');
+    await expect(card).toHaveAttribute('data-revealing', 'true');
+
+    // Entweder ein Wort ODER "DU BIST DER IMPOSTER" ist sichtbar
+    const isImpostor = await page.getByTestId('impostor-label').isVisible().catch(() => false);
+    if (isImpostor) {
+      // Mit show_category_to_impostor=true muss auch der Themen-Hinweis da sein
+      await expect(page.getByTestId('impostor-category-hint')).toBeVisible();
+    } else {
+      await expect(page.getByTestId('player-word')).toBeVisible();
+    }
+
+    // Loslassen → Karte wieder verdeckt
+    await card.dispatchEvent('pointerup');
+    await expect(card).toHaveAttribute('data-revealing', 'false');
+    await expect(page.getByTestId('player-word')).not.toBeVisible();
+    await expect(page.getByTestId('impostor-label')).not.toBeVisible();
+
+    // Nächster Spieler
+    await page.getByTestId('next-player').click();
+    await expect(page.getByTestId('current-player')).toHaveText('Bob');
+
+    // Bob: nur kurz halten + weiter
+    await card.dispatchEvent('pointerdown');
+    await card.dispatchEvent('pointerup');
+    await page.getByTestId('next-player').click();
+
+    // Carol: letzter Spieler — Button heißt "Fertig"
+    await expect(page.getByTestId('current-player')).toHaveText('Carol');
+    await expect(page.getByTestId('next-player')).toHaveText('Fertig');
+    await card.dispatchEvent('pointerdown');
+    await card.dispatchEvent('pointerup');
+    await page.getByTestId('next-player').click();
+
+    // ---------- Bereitschafts-Screen ----------
+
+    await expect(page.getByRole('heading', { name: 'Alle bereit' })).toBeVisible();
+    await page.getByTestId('show-resolution').click();
+
+    // ---------- Auflösung ----------
+
+    await expect(page.getByRole('heading', { name: 'Auflösung' })).toBeVisible();
+
+    // Imposter-Name ist einer der drei Spieler
+    const impostorName = await page.getByTestId('impostor-name').textContent();
+    expect(['Alice', 'Bob', 'Carol']).toContain(impostorName?.trim());
+
+    // Wort wird angezeigt
+    await expect(page.getByTestId('resolved-word')).toBeVisible();
+    const word = await page.getByTestId('resolved-word').textContent();
+    expect(word?.trim().length).toBeGreaterThan(0);
+
+    // Neue Runde führt zurück zum Setup
+    await page.getByTestId('new-round').click();
+    await expect(page.getByRole('heading', { name: 'Impostor' })).toBeVisible();
+    await expect(page.getByTestId('start-button')).toBeVisible();
+  });
+
+  test('Navbar enthält Impostor-Link auch ohne Login', async ({ page }) => {
+    await page.goto('/');
+    // Desktop-Link sollte da sein
+    await expect(page.getByRole('link', { name: 'Impostor' }).first()).toBeVisible();
+  });
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,6 +20,8 @@ import { ForgotPassword } from './pages/ForgotPassword';
 import { ResetPassword } from './pages/ResetPassword';
 import { SeasonalCalendar } from './pages/SeasonalCalendar';
 import { SeasonalCalendarAdmin } from './pages/SeasonalCalendarAdmin';
+import { Impostor } from './pages/Impostor';
+import { AdminImpostor } from './pages/AdminImpostor';
 
 function App() {
   return (
@@ -40,11 +42,13 @@ function App() {
         {/* Alte URL → neue Admin-URL */}
         <Route path="/saisonkalender/admin" element={<Navigate to="/admin/saisonkalender" replace />} />
         <Route path="/einkaufsliste" element={<Shopping />} />
+        <Route path="/impostor" element={<Impostor />} />
         <Route path="/account" element={<Account />} />
         <Route path="/admin" element={<Navigate to="/admin/users" replace />} />
         <Route path="/admin/users" element={<AdminUsers />} />
         <Route path="/admin/tags" element={<AdminTags />} />
         <Route path="/admin/saisonkalender" element={<SeasonalCalendarAdmin />} />
+        <Route path="/admin/impostor" element={<AdminImpostor />} />
         <Route path="/admin/einstellungen" element={<AdminSettings />} />
         <Route path="/forgot-password" element={<ForgotPassword />} />
         <Route path="/reset-password" element={<ResetPassword />} />

--- a/frontend/src/api/impostor.ts
+++ b/frontend/src/api/impostor.ts
@@ -1,0 +1,79 @@
+/**
+ * API-Client für das Impostor-Spiel.
+ * Public-Endpoints: list aktive Kategorien, hole zufälliges Wort.
+ * Admin-Endpoints: CRUD für Kategorien und Wörter.
+ */
+
+import { api } from '../lib/api';
+import type {
+  ImpostorCategoryPublic,
+  ImpostorCategoryAdmin,
+  ImpostorWord,
+  ImpostorRandomResponse,
+} from '../types';
+
+// ---------- Public ----------
+
+export async function listImpostorCategories(): Promise<ImpostorCategoryPublic[]> {
+  return api<ImpostorCategoryPublic[]>('/impostor/categories');
+}
+
+export async function getImpostorRandomWord(
+  categoryIds: number[],
+): Promise<ImpostorRandomResponse> {
+  return api<ImpostorRandomResponse>('/impostor/random', {
+    method: 'POST',
+    body: JSON.stringify({ category_ids: categoryIds }),
+  });
+}
+
+// ---------- Admin: Categories ----------
+
+export async function adminListImpostorCategories(): Promise<ImpostorCategoryAdmin[]> {
+  return api<ImpostorCategoryAdmin[]>('/impostor/admin/categories');
+}
+
+export async function adminCreateImpostorCategory(payload: {
+  name: string;
+  is_active?: boolean;
+  sort_order?: number;
+}): Promise<ImpostorCategoryAdmin> {
+  return api<ImpostorCategoryAdmin>('/impostor/admin/categories', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function adminUpdateImpostorCategory(
+  id: number,
+  payload: { name?: string; is_active?: boolean; sort_order?: number },
+): Promise<ImpostorCategoryAdmin> {
+  return api<ImpostorCategoryAdmin>(`/impostor/admin/categories/${id}`, {
+    method: 'PATCH',
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function adminDeleteImpostorCategory(id: number): Promise<void> {
+  return api<void>(`/impostor/admin/categories/${id}`, { method: 'DELETE' });
+}
+
+// ---------- Admin: Words ----------
+
+export async function adminListImpostorWords(categoryId: number): Promise<ImpostorWord[]> {
+  return api<ImpostorWord[]>(`/impostor/admin/categories/${categoryId}/words`);
+}
+
+export async function adminCreateImpostorWords(
+  categoryId: number,
+  words: string[],
+): Promise<ImpostorWord[]> {
+  return api<ImpostorWord[]>(`/impostor/admin/categories/${categoryId}/words`, {
+    method: 'POST',
+    body: JSON.stringify({ words }),
+  });
+}
+
+export async function adminDeleteImpostorWord(wordId: number): Promise<void> {
+  return api<void>(`/impostor/admin/words/${wordId}`, { method: 'DELETE' });
+}

--- a/frontend/src/components/AdminLayout.tsx
+++ b/frontend/src/components/AdminLayout.tsx
@@ -43,6 +43,7 @@ export function AdminLayout({ children }: Props) {
           <NavLink to="/admin/users" className={tabClass}>Nutzer</NavLink>
           <NavLink to="/admin/tags" className={tabClass}>Tags</NavLink>
           <NavLink to="/admin/saisonkalender" className={tabClass}>Saisonkalender</NavLink>
+          <NavLink to="/admin/impostor" className={tabClass}>Impostor</NavLink>
           <NavLink to="/admin/einstellungen" className={tabClass}>Einstellungen</NavLink>
         </div>
         {children}

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -28,6 +28,7 @@ export function Navbar() {
         </Link>
 
         <div className="hidden md:flex gap-6">
+          <Link to="/impostor" className={linkClass}>Impostor</Link>
           {user && (
             <>
               {user.is_admin && (
@@ -101,6 +102,7 @@ export function Navbar() {
           onClick={() => setOpen(false)}
         >
           <div className="px-6 py-4" onClick={e => e.stopPropagation()}>
+            <Link to="/impostor" className={mobileLinkClass}>Impostor</Link>
             {user ? (
               <>
                 {user.is_admin && (

--- a/frontend/src/pages/AdminImpostor.tsx
+++ b/frontend/src/pages/AdminImpostor.tsx
@@ -1,0 +1,435 @@
+import { useCallback, useEffect, useState } from 'react';
+import { AdminLayout } from '../components/AdminLayout';
+import { Button } from '../components/Button';
+import { Modal } from '../components/Modal';
+import {
+  adminListImpostorCategories,
+  adminCreateImpostorCategory,
+  adminUpdateImpostorCategory,
+  adminDeleteImpostorCategory,
+  adminListImpostorWords,
+  adminCreateImpostorWords,
+  adminDeleteImpostorWord,
+} from '../api/impostor';
+import type { ImpostorCategoryAdmin, ImpostorWord } from '../types';
+
+type ModalKind =
+  | { kind: 'none' }
+  | { kind: 'create' }
+  | { kind: 'rename'; cat: ImpostorCategoryAdmin }
+  | { kind: 'words'; cat: ImpostorCategoryAdmin };
+
+export function AdminImpostor() {
+  const [categories, setCategories] = useState<ImpostorCategoryAdmin[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  // Modal-State
+  const [modal, setModal] = useState<ModalKind>({ kind: 'none' });
+  const [modalInput, setModalInput] = useState('');
+  const [modalError, setModalError] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  // Words-Modal-spezifisch
+  const [words, setWords] = useState<ImpostorWord[]>([]);
+  const [loadingWords, setLoadingWords] = useState(false);
+  const [newWordsInput, setNewWordsInput] = useState('');
+  const [addingWords, setAddingWords] = useState(false);
+
+  const inputClass = 'w-full px-3 py-2 text-sm rounded-lg border border-border bg-bg-primary focus:outline-none focus:border-text-muted';
+
+  // ---------- Categories laden ----------
+
+  useEffect(() => {
+    let cancelled = false;
+    adminListImpostorCategories()
+      .then((data) => {
+        if (cancelled) return;
+        setCategories(data);
+      })
+      .catch((e) => {
+        if (cancelled) return;
+        setError(e instanceof Error ? e.message : 'Fehler beim Laden');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, []);
+
+  // ---------- Words laden, sobald words-Modal aufgeht ----------
+
+  useEffect(() => {
+    if (modal.kind !== 'words') return;
+    let cancelled = false;
+    setLoadingWords(true);
+    setModalError('');
+    adminListImpostorWords(modal.cat.id)
+      .then((data) => {
+        if (!cancelled) setWords(data);
+      })
+      .catch((e) => {
+        if (!cancelled) setModalError(e instanceof Error ? e.message : 'Fehler beim Laden');
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingWords(false);
+      });
+    return () => { cancelled = true; };
+  }, [modal]);
+
+  // ---------- Modal-Helpers ----------
+
+  const closeModal = useCallback(() => {
+    if (submitting || addingWords) return;
+    setModal({ kind: 'none' });
+    setModalInput('');
+    setModalError('');
+    setNewWordsInput('');
+    setWords([]);
+  }, [submitting, addingWords]);
+
+  // Esc + body-scroll-lock
+  useEffect(() => {
+    if (modal.kind === 'none') return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') closeModal();
+    };
+    document.addEventListener('keydown', onKey);
+    const prevOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.removeEventListener('keydown', onKey);
+      document.body.style.overflow = prevOverflow;
+    };
+  }, [modal.kind, closeModal]);
+
+  function openCreate() {
+    setModalInput('');
+    setModalError('');
+    setModal({ kind: 'create' });
+  }
+
+  function openRename(cat: ImpostorCategoryAdmin) {
+    setModalInput(cat.name);
+    setModalError('');
+    setModal({ kind: 'rename', cat });
+  }
+
+  function openWords(cat: ImpostorCategoryAdmin) {
+    setNewWordsInput('');
+    setModalError('');
+    setWords([]);
+    setModal({ kind: 'words', cat });
+  }
+
+  // ---------- Submit-Handlers ----------
+
+  async function submitCreate() {
+    const name = modalInput.trim();
+    if (!name) {
+      setModalError('Name darf nicht leer sein');
+      return;
+    }
+    setSubmitting(true);
+    setModalError('');
+    try {
+      const cat = await adminCreateImpostorCategory({
+        name,
+        sort_order: categories.length,
+      });
+      setCategories((prev) => [...prev, cat]);
+      setModal({ kind: 'none' });
+      setModalInput('');
+    } catch (e) {
+      setModalError(e instanceof Error ? e.message : 'Fehler');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function submitRename() {
+    if (modal.kind !== 'rename') return;
+    const newName = modalInput.trim();
+    if (!newName) {
+      setModalError('Name darf nicht leer sein');
+      return;
+    }
+    if (newName === modal.cat.name) {
+      closeModal();
+      return;
+    }
+    setSubmitting(true);
+    setModalError('');
+    try {
+      const updated = await adminUpdateImpostorCategory(modal.cat.id, { name: newName });
+      setCategories((prev) => prev.map((c) => (c.id === updated.id ? updated : c)));
+      setModal({ kind: 'none' });
+      setModalInput('');
+    } catch (e) {
+      setModalError(e instanceof Error ? e.message : 'Fehler');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  // Wörter-Modal-Aktionen
+  async function addNewWords() {
+    if (modal.kind !== 'words') return;
+    const list = newWordsInput
+      .split(/[\n,]/)
+      .map((w) => w.trim())
+      .filter((w) => w.length > 0);
+    if (list.length === 0) {
+      setModalError('Bitte mindestens ein Wort eingeben');
+      return;
+    }
+    setAddingWords(true);
+    setModalError('');
+    try {
+      const created = await adminCreateImpostorWords(modal.cat.id, list);
+      setWords((prev) =>
+        [...prev, ...created].sort((a, b) => a.word.localeCompare(b.word, 'de')),
+      );
+      // Word-count auf der Karte aktualisieren
+      setCategories((prev) =>
+        prev.map((c) =>
+          c.id === modal.cat.id ? { ...c, word_count: c.word_count + created.length } : c,
+        ),
+      );
+      setNewWordsInput('');
+    } catch (e) {
+      setModalError(e instanceof Error ? e.message : 'Fehler');
+    } finally {
+      setAddingWords(false);
+    }
+  }
+
+  async function removeWordInModal(word: ImpostorWord) {
+    if (modal.kind !== 'words') return;
+    if (!confirm(`Wort "${word.word}" löschen?`)) return;
+    try {
+      await adminDeleteImpostorWord(word.id);
+      setWords((prev) => prev.filter((w) => w.id !== word.id));
+      setCategories((prev) =>
+        prev.map((c) =>
+          c.id === modal.cat.id ? { ...c, word_count: Math.max(0, c.word_count - 1) } : c,
+        ),
+      );
+    } catch (e) {
+      setModalError(e instanceof Error ? e.message : 'Fehler');
+    }
+  }
+
+  // ---------- Direkt-Aktionen (kein Modal) ----------
+
+  async function toggleActive(cat: ImpostorCategoryAdmin) {
+    try {
+      const updated = await adminUpdateImpostorCategory(cat.id, { is_active: !cat.is_active });
+      setCategories((prev) => prev.map((c) => (c.id === cat.id ? updated : c)));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Fehler');
+    }
+  }
+
+  async function deleteCategory(cat: ImpostorCategoryAdmin) {
+    if (!confirm(`Kategorie "${cat.name}" wirklich löschen? Alle ${cat.word_count} Wörter werden mitgelöscht.`)) {
+      return;
+    }
+    try {
+      await adminDeleteImpostorCategory(cat.id);
+      setCategories((prev) => prev.filter((c) => c.id !== cat.id));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Fehler');
+    }
+  }
+
+  if (loading) {
+    return <AdminLayout><p className="text-text-muted">Lade...</p></AdminLayout>;
+  }
+
+  return (
+    <AdminLayout>
+      <div className="flex items-center justify-between mb-6">
+        <h2 className="text-sm font-medium uppercase tracking-wider text-text-muted">
+          Impostor
+        </h2>
+        <Button variant="primary" onClick={openCreate}>
+          + Neue Kategorie
+        </Button>
+      </div>
+
+      {error && <p className="text-red-600 bg-red-50 p-4 rounded mb-4">{error}</p>}
+
+      {/* ---------- Kategorien-Liste ---------- */}
+      {categories.length === 0 ? (
+        <p className="text-text-muted text-sm">Noch keine Kategorien angelegt.</p>
+      ) : (
+        <div className="space-y-2">
+          {categories.map((cat) => (
+            <div
+              key={cat.id}
+              className="rounded-lg border border-border bg-bg-secondary p-3"
+            >
+              <div className="flex items-center justify-between gap-2 flex-wrap">
+                <button
+                  type="button"
+                  onClick={() => openWords(cat)}
+                  className="flex items-center gap-2 text-left flex-1 min-w-0 hover:text-text-primary"
+                  title="Wörter bearbeiten"
+                >
+                  <span className="font-medium truncate">{cat.name}</span>
+                  <span className="text-xs text-text-muted">({cat.word_count})</span>
+                  {!cat.is_active && (
+                    <span className="text-xs text-text-muted bg-bg-primary px-2 py-0.5 rounded border border-border">
+                      inaktiv
+                    </span>
+                  )}
+                </button>
+                <div className="flex gap-1 flex-wrap">
+                  <button
+                    type="button"
+                    onClick={() => toggleActive(cat)}
+                    className="text-xs px-2 py-1 rounded border border-border hover:bg-bg-primary"
+                  >
+                    {cat.is_active ? 'Deaktivieren' : 'Aktivieren'}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => openRename(cat)}
+                    className="text-xs px-2 py-1 rounded border border-border hover:bg-bg-primary"
+                  >
+                    Umbenennen
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => deleteCategory(cat)}
+                    className="text-xs px-2 py-1 rounded border border-red-600 text-red-600 hover:bg-red-50"
+                  >
+                    Löschen
+                  </button>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* =================================================================
+          MODALS
+          ================================================================= */}
+
+      {modal.kind === 'create' && (
+        <Modal
+          title="Neue Kategorie"
+          onClose={closeModal}
+          onConfirm={submitCreate}
+          confirmLabel={submitting ? 'Lege an...' : 'Anlegen'}
+        >
+          <label className="block text-sm font-medium mb-2">Name</label>
+          <input
+            type="text"
+            value={modalInput}
+            onChange={(e) => setModalInput(e.target.value)}
+            placeholder="z.B. Werkzeuge"
+            maxLength={100}
+            autoFocus
+            disabled={submitting}
+            onKeyDown={(e) => { if (e.key === 'Enter') submitCreate(); }}
+            className={inputClass}
+          />
+          {modalError && <p className="text-red-600 text-sm mt-2">{modalError}</p>}
+        </Modal>
+      )}
+
+      {modal.kind === 'rename' && (
+        <Modal
+          title="Kategorie umbenennen"
+          onClose={closeModal}
+          onConfirm={submitRename}
+          confirmLabel={submitting ? 'Speichere...' : 'Speichern'}
+        >
+          <label className="block text-sm font-medium mb-2">Neuer Name</label>
+          <input
+            type="text"
+            value={modalInput}
+            onChange={(e) => setModalInput(e.target.value)}
+            maxLength={100}
+            autoFocus
+            disabled={submitting}
+            onKeyDown={(e) => { if (e.key === 'Enter') submitRename(); }}
+            className={inputClass}
+          />
+          {modalError && <p className="text-red-600 text-sm mt-2">{modalError}</p>}
+        </Modal>
+      )}
+
+      {modal.kind === 'words' && (
+        <Modal title={`Wörter — ${modal.cat.name}`} onClose={closeModal}>
+          <div className="space-y-4">
+            {/* Bestehende Wörter */}
+            <div>
+              <p className="text-sm font-medium mb-2">
+                Bestehende Wörter ({words.length})
+              </p>
+              {loadingWords ? (
+                <p className="text-text-muted text-sm">Lade Wörter...</p>
+              ) : words.length === 0 ? (
+                <p className="text-text-muted text-sm">
+                  Noch keine Wörter in dieser Kategorie.
+                </p>
+              ) : (
+                <div className="flex flex-wrap gap-2 max-h-64 overflow-y-auto p-1 -m-1">
+                  {words.map((w) => (
+                    <span
+                      key={w.id}
+                      className="inline-flex items-center gap-1 px-2 py-1 text-sm rounded border border-border bg-bg-secondary"
+                    >
+                      {w.word}
+                      <button
+                        type="button"
+                        onClick={() => removeWordInModal(w)}
+                        className="text-text-muted hover:text-red-600 ml-1 text-xs"
+                        aria-label={`${w.word} löschen`}
+                      >
+                        ✕
+                      </button>
+                    </span>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            {/* Neue Wörter hinzufügen */}
+            <div className="border-t border-border pt-4">
+              <label className="block text-sm font-medium mb-2">
+                Neue Wörter hinzufügen
+              </label>
+              <textarea
+                value={newWordsInput}
+                onChange={(e) => setNewWordsInput(e.target.value)}
+                placeholder="Ein Wort pro Zeile oder durch Kommas getrennt"
+                rows={3}
+                disabled={addingWords}
+                className={inputClass}
+              />
+              <p className="text-xs text-text-muted mt-1">
+                Duplikate werden automatisch übersprungen.
+              </p>
+              <div className="mt-2 flex justify-end">
+                <Button
+                  variant="primary"
+                  onClick={addNewWords}
+                  disabled={addingWords || !newWordsInput.trim()}
+                >
+                  {addingWords ? 'Füge hinzu...' : 'Hinzufügen'}
+                </Button>
+              </div>
+            </div>
+
+            {modalError && <p className="text-red-600 text-sm">{modalError}</p>}
+          </div>
+        </Modal>
+      )}
+    </AdminLayout>
+  );
+}

--- a/frontend/src/pages/Impostor.tsx
+++ b/frontend/src/pages/Impostor.tsx
@@ -1,0 +1,460 @@
+import { useEffect, useState, useCallback } from 'react';
+import { Layout } from '../components/Layout';
+import { Button } from '../components/Button';
+import {
+  listImpostorCategories,
+  getImpostorRandomWord,
+} from '../api/impostor';
+import type {
+  ImpostorCategoryPublic,
+  ImpostorRandomResponse,
+} from '../types';
+
+type GameState = 'setup' | 'reveal' | 'summary';
+
+interface RoundData {
+  word: string;
+  categoryName: string;
+  impostorIndex: number;
+  showCategoryToImpostor: boolean;
+}
+
+const MIN_PLAYERS = 3;
+const MAX_PLAYERS = 10;
+
+export function Impostor() {
+  // ---------- Setup-State ----------
+  const [categories, setCategories] = useState<ImpostorCategoryPublic[]>([]);
+  const [loadingCats, setLoadingCats] = useState(true);
+  const [loadError, setLoadError] = useState('');
+
+  const [selectedCatIds, setSelectedCatIds] = useState<Set<number>>(new Set());
+  const [playerCount, setPlayerCount] = useState(4);
+  const [playerNames, setPlayerNames] = useState<string[]>(['', '', '', '']);
+  const [showCategoryToImpostor, setShowCategoryToImpostor] = useState(false);
+
+  // ---------- Spiel-State ----------
+  const [gameState, setGameState] = useState<GameState>('setup');
+  const [round, setRound] = useState<RoundData | null>(null);
+  const [currentPlayerIdx, setCurrentPlayerIdx] = useState(0);
+  const [revealing, setRevealing] = useState(false); // tap-and-hold aktiv
+  const [seenPlayers, setSeenPlayers] = useState<Set<number>>(new Set());
+
+  const [startError, setStartError] = useState('');
+  const [starting, setStarting] = useState(false);
+
+  // ---------- Categories laden ----------
+
+  useEffect(() => {
+    let cancelled = false;
+    listImpostorCategories()
+      .then((data) => {
+        if (cancelled) return;
+        setCategories(data);
+        // Default: alle vorausgewählt
+        setSelectedCatIds(new Set(data.map((c) => c.id)));
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setLoadError(err instanceof Error ? err.message : 'Fehler beim Laden');
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingCats(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // ---------- Playercount-Änderung: Namen-Array anpassen ----------
+
+  function updatePlayerCount(n: number) {
+    const clamped = Math.max(MIN_PLAYERS, Math.min(MAX_PLAYERS, n));
+    setPlayerCount(clamped);
+    setPlayerNames((prev) => {
+      const next = [...prev];
+      while (next.length < clamped) next.push('');
+      next.length = clamped;
+      return next;
+    });
+  }
+
+  function updatePlayerName(idx: number, name: string) {
+    setPlayerNames((prev) => {
+      const next = [...prev];
+      next[idx] = name;
+      return next;
+    });
+  }
+
+  function toggleCategory(id: number) {
+    setSelectedCatIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  // ---------- Validierung ----------
+
+  function validateSetup(): string | null {
+    if (selectedCatIds.size === 0) return 'Bitte mindestens eine Kategorie auswählen.';
+    const trimmed = playerNames.map((n) => n.trim());
+    if (trimmed.some((n) => !n)) return 'Bitte alle Spielernamen eingeben.';
+    const lower = trimmed.map((n) => n.toLowerCase());
+    if (new Set(lower).size !== lower.length) return 'Spielernamen müssen eindeutig sein.';
+    return null;
+  }
+
+  // ---------- Spielstart ----------
+
+  async function startGame() {
+    setStartError('');
+    const err = validateSetup();
+    if (err) {
+      setStartError(err);
+      return;
+    }
+    setStarting(true);
+    try {
+      const data: ImpostorRandomResponse = await getImpostorRandomWord(
+        Array.from(selectedCatIds),
+      );
+      const impostorIdx = Math.floor(Math.random() * playerCount);
+      setRound({
+        word: data.word,
+        categoryName: data.category_name,
+        impostorIndex: impostorIdx,
+        showCategoryToImpostor,
+      });
+      setCurrentPlayerIdx(0);
+      setSeenPlayers(new Set());
+      setRevealing(false);
+      setGameState('reveal');
+    } catch (e) {
+      setStartError(e instanceof Error ? e.message : 'Spielstart fehlgeschlagen');
+    } finally {
+      setStarting(false);
+    }
+  }
+
+  // ---------- Reveal-Logik ----------
+
+  const handleHoldStart = useCallback(() => setRevealing(true), []);
+  const handleHoldEnd = useCallback(() => setRevealing(false), []);
+
+  function nextPlayer() {
+    setSeenPlayers((prev) => new Set(prev).add(currentPlayerIdx));
+    setRevealing(false);
+    if (currentPlayerIdx + 1 >= playerCount) {
+      // Letzter Spieler war dran → Ready für Auflösung
+      setCurrentPlayerIdx(playerCount); // markiert "fertig"
+    } else {
+      setCurrentPlayerIdx(currentPlayerIdx + 1);
+    }
+  }
+
+  function showResolution() {
+    setGameState('summary');
+  }
+
+  function newRound() {
+    // Gleiche Spieler, neue Wort+Imposter-Auslosung
+    setRound(null);
+    setCurrentPlayerIdx(0);
+    setSeenPlayers(new Set());
+    setRevealing(false);
+    setStartError('');
+    setGameState('setup');
+  }
+
+  // ---------- Render-Helpers ----------
+
+  const trimmedNames = playerNames.map((n) => n.trim());
+  const allPlayersSeen = currentPlayerIdx >= playerCount;
+  const currentName = !allPlayersSeen ? trimmedNames[currentPlayerIdx] || `Spieler ${currentPlayerIdx + 1}` : '';
+  const isImpostor = round && currentPlayerIdx === round.impostorIndex;
+
+  // ===================================================================
+  // SETUP-VIEW
+  // ===================================================================
+  if (gameState === 'setup') {
+    return (
+      <Layout>
+        <div className="max-w-2xl mx-auto px-4 sm:px-8 py-8 sm:py-12">
+          <h1 className="text-2xl sm:text-3xl font-medium mb-2">Impostor</h1>
+          <p className="text-sm text-text-muted mb-8">
+            Alle Spieler sehen das gleiche Wort — bis auf einen, den Impostor.
+            In der Diskussion müsst ihr ihn entlarven.
+          </p>
+
+          {loadingCats ? (
+            <p className="text-text-muted">Lade Kategorien...</p>
+          ) : loadError ? (
+            <p className="text-red-600">{loadError}</p>
+          ) : categories.length === 0 ? (
+            <p className="text-text-muted">Keine Kategorien verfügbar.</p>
+          ) : (
+            <>
+              {/* ---------- Spieleranzahl ---------- */}
+              <section className="mb-8">
+                <h2 className="text-lg font-medium mb-3">Spieleranzahl</h2>
+                <div className="flex items-center gap-3">
+                  <button
+                    type="button"
+                    onClick={() => updatePlayerCount(playerCount - 1)}
+                    disabled={playerCount <= MIN_PLAYERS}
+                    className="w-10 h-10 rounded-lg border border-border bg-bg-secondary text-xl disabled:opacity-30"
+                    aria-label="Spieler entfernen"
+                  >−</button>
+                  <span className="text-xl font-medium w-10 text-center" data-testid="player-count">
+                    {playerCount}
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => updatePlayerCount(playerCount + 1)}
+                    disabled={playerCount >= MAX_PLAYERS}
+                    className="w-10 h-10 rounded-lg border border-border bg-bg-secondary text-xl disabled:opacity-30"
+                    aria-label="Spieler hinzufügen"
+                  >+</button>
+                  <span className="text-xs text-text-muted ml-2">
+                    {MIN_PLAYERS}–{MAX_PLAYERS} Spieler
+                  </span>
+                </div>
+              </section>
+
+              {/* ---------- Spielernamen ---------- */}
+              <section className="mb-8">
+                <h2 className="text-lg font-medium mb-3">Spielernamen</h2>
+                <div className="space-y-2">
+                  {Array.from({ length: playerCount }, (_, i) => (
+                    <input
+                      key={i}
+                      type="text"
+                      value={playerNames[i] ?? ''}
+                      onChange={(e) => updatePlayerName(i, e.target.value)}
+                      placeholder={`Spieler ${i + 1}`}
+                      maxLength={40}
+                      className="w-full px-3 py-2 text-sm rounded-lg border border-border bg-bg-primary focus:outline-none focus:border-text-muted"
+                      data-testid={`player-name-${i}`}
+                    />
+                  ))}
+                </div>
+              </section>
+
+              {/* ---------- Kategorien ---------- */}
+              <section className="mb-8">
+                <div className="flex items-baseline justify-between mb-3">
+                  <h2 className="text-lg font-medium">Kategorien</h2>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      if (selectedCatIds.size === categories.length) {
+                        setSelectedCatIds(new Set());
+                      } else {
+                        setSelectedCatIds(new Set(categories.map((c) => c.id)));
+                      }
+                    }}
+                    className="text-xs text-text-muted hover:text-text-primary underline"
+                  >
+                    {selectedCatIds.size === categories.length ? 'Alle abwählen' : 'Alle auswählen'}
+                  </button>
+                </div>
+                <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+                  {categories.map((cat) => {
+                    const checked = selectedCatIds.has(cat.id);
+                    return (
+                      <label
+                        key={cat.id}
+                        className={`flex items-center gap-2 px-3 py-2 rounded-lg border cursor-pointer text-sm transition-colors ${
+                          checked
+                            ? 'border-accent bg-accent/10 text-text-primary'
+                            : 'border-border bg-bg-secondary text-text-muted hover:text-text-primary'
+                        }`}
+                      >
+                        <input
+                          type="checkbox"
+                          checked={checked}
+                          onChange={() => toggleCategory(cat.id)}
+                          className="sr-only"
+                          data-testid={`category-${cat.id}`}
+                        />
+                        <span className="truncate">{cat.name}</span>
+                        <span className="ml-auto text-xs text-text-muted">{cat.word_count}</span>
+                      </label>
+                    );
+                  })}
+                </div>
+              </section>
+
+              {/* ---------- Optionen ---------- */}
+              <section className="mb-8">
+                <label className="flex items-center gap-3 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={showCategoryToImpostor}
+                    onChange={(e) => setShowCategoryToImpostor(e.target.checked)}
+                    className="w-4 h-4"
+                    data-testid="show-category-to-impostor"
+                  />
+                  <span className="text-sm">Impostor erfährt die Kategorie</span>
+                </label>
+                <p className="text-xs text-text-muted mt-1 ml-7">
+                  Bei „aus" sieht der Impostor nur „DU BIST DER IMPOSTER".
+                </p>
+              </section>
+
+              {startError && (
+                <p className="text-red-600 text-sm mb-4" data-testid="start-error">{startError}</p>
+              )}
+
+              <Button onClick={startGame} disabled={starting} data-testid="start-button">
+                {starting ? 'Starte...' : 'Spiel starten'}
+              </Button>
+            </>
+          )}
+        </div>
+      </Layout>
+    );
+  }
+
+  // ===================================================================
+  // REVEAL-VIEW (alle Spieler durch)
+  // ===================================================================
+  if (gameState === 'reveal' && round) {
+    if (allPlayersSeen) {
+      return (
+        <Layout>
+          <div className="max-w-2xl mx-auto px-4 sm:px-8 py-8 sm:py-12 text-center">
+            <h1 className="text-2xl sm:text-3xl font-medium mb-4">Alle bereit</h1>
+            <p className="text-text-muted mb-8">
+              Jetzt diskutiert und stimmt ab, wer der Impostor ist.
+              Wenn ihr fertig seid, klickt auf Auflösung.
+            </p>
+            <Button onClick={showResolution} data-testid="show-resolution">
+              Auflösung anzeigen
+            </Button>
+          </div>
+        </Layout>
+      );
+    }
+
+    return (
+      <Layout>
+        <div className="max-w-2xl mx-auto px-4 sm:px-8 py-8 sm:py-12">
+          <p className="text-sm text-text-muted text-center mb-2">
+            Spieler {currentPlayerIdx + 1} von {playerCount}
+          </p>
+          <h1 className="text-2xl sm:text-3xl font-medium text-center mb-8" data-testid="current-player">
+            {currentName}
+          </h1>
+
+          <div
+            className={`relative aspect-[3/2] rounded-2xl border-2 select-none overflow-hidden mb-6 ${
+              revealing
+                ? 'border-accent bg-bg-secondary'
+                : 'border-border bg-bg-primary'
+            }`}
+            onPointerDown={(e) => { e.preventDefault(); handleHoldStart(); }}
+            onPointerUp={handleHoldEnd}
+            onPointerLeave={handleHoldEnd}
+            onPointerCancel={handleHoldEnd}
+            onContextMenu={(e) => e.preventDefault()}
+            data-testid="reveal-card"
+            data-revealing={revealing ? 'true' : 'false'}
+          >
+            {revealing ? (
+              <div className="absolute inset-0 flex items-center justify-center p-6 text-center">
+                {isImpostor ? (
+                  <div>
+                    <p className="text-3xl sm:text-4xl font-bold text-red-600 mb-3" data-testid="impostor-label">
+                      DU BIST DER IMPOSTER
+                    </p>
+                    {round.showCategoryToImpostor && (
+                      <p className="text-base text-text-muted" data-testid="impostor-category-hint">
+                        Thema: {round.categoryName}
+                      </p>
+                    )}
+                  </div>
+                ) : (
+                  <p className="text-3xl sm:text-4xl font-medium" data-testid="player-word">
+                    {round.word}
+                  </p>
+                )}
+              </div>
+            ) : (
+              <div className="absolute inset-0 flex flex-col items-center justify-center p-6 text-center">
+                <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="text-text-muted mb-3">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7z" />
+                  <circle cx="12" cy="12" r="3" />
+                </svg>
+                <p className="text-base text-text-muted mb-1">Halten zum Anzeigen</p>
+                <p className="text-xs text-text-muted">
+                  Loslassen versteckt das Wort wieder
+                </p>
+              </div>
+            )}
+          </div>
+
+          <div className="flex justify-center">
+            <Button
+              variant="secondary"
+              onClick={nextPlayer}
+              disabled={revealing}
+              data-testid="next-player"
+            >
+              {currentPlayerIdx + 1 === playerCount ? 'Fertig' : 'Nächster Spieler'}
+            </Button>
+          </div>
+
+          {seenPlayers.size > 0 && (
+            <p className="text-xs text-text-muted text-center mt-4">
+              {seenPlayers.size} von {playerCount} haben gesehen
+            </p>
+          )}
+        </div>
+      </Layout>
+    );
+  }
+
+  // ===================================================================
+  // SUMMARY-VIEW
+  // ===================================================================
+  if (gameState === 'summary' && round) {
+    const impostorName =
+      trimmedNames[round.impostorIndex] || `Spieler ${round.impostorIndex + 1}`;
+    return (
+      <Layout>
+        <div className="max-w-2xl mx-auto px-4 sm:px-8 py-8 sm:py-12 text-center">
+          <h1 className="text-2xl sm:text-3xl font-medium mb-8">Auflösung</h1>
+
+          <div className="rounded-2xl border border-border bg-bg-secondary p-6 sm:p-8 mb-6">
+            <p className="text-sm text-text-muted mb-2">Der Impostor war</p>
+            <p className="text-3xl sm:text-4xl font-bold text-red-600 mb-6" data-testid="impostor-name">
+              {impostorName}
+            </p>
+            <p className="text-sm text-text-muted mb-2">Das Wort war</p>
+            <p className="text-2xl sm:text-3xl font-medium mb-1" data-testid="resolved-word">
+              {round.word}
+            </p>
+            <p className="text-sm text-text-muted">aus {round.categoryName}</p>
+          </div>
+
+          <Button onClick={newRound} data-testid="new-round">
+            Neue Runde
+          </Button>
+        </div>
+      </Layout>
+    );
+  }
+
+  // Fallback (sollte nie erreicht werden)
+  return (
+    <Layout>
+      <div className="max-w-2xl mx-auto px-4 sm:px-8 py-8">
+        <p className="text-text-muted">Unbekannter Spielzustand.</p>
+      </div>
+    </Layout>
+  );
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -143,3 +143,31 @@ export interface SeasonalItemInput {
   availabilities: MonthAvailability[];
   notes?: string | null;
 }
+
+// ---------- Impostor-Spiel ----------
+
+export interface ImpostorCategoryPublic {
+  id: number;
+  name: string;
+  word_count: number;
+}
+
+export interface ImpostorCategoryAdmin {
+  id: number;
+  name: string;
+  is_active: boolean;
+  sort_order: number;
+  word_count: number;
+  created_at: string;
+}
+
+export interface ImpostorWord {
+  id: number;
+  word: string;
+}
+
+export interface ImpostorRandomResponse {
+  word: string;
+  category_id: number;
+  category_name: string;
+}


### PR DESCRIPTION
Adds an offline-friendly party game playable at `/impostor` (no login required).

## Features
- **Setup**: 3–10 players (with names), category multi-select, optional toggle
  whether the impostor sees the category name
- **Reveal phase**: tap-and-hold to show each player their word; releasing
  hides it again before passing the device on
- **Resolution**: shows who the impostor was and what the word was, with a
  "neue Runde" button to start over with the same player setup
- **Admin UI** at `/admin/impostor`: full CRUD for categories and words via
  modal dialogs (matches the existing Saisonkalender-Admin pattern)

## Backend
- New `impostor_categories` and `impostor_words` tables with cascade delete
- Public endpoints: `GET /impostor/categories`, `POST /impostor/random`
- Admin endpoints: full category CRUD + bulk word add with auto-dedup
- 600 seeded words across 20 categories (food, animals, professions, etc.)
- 35 backend tests, all passing

## Frontend
- New routes wired into existing `App.tsx`
- "Impostor" link in main nav (visible to guests too)
- "Impostor" tab in admin dashboard

## Tests
- Backend: 35 unit tests covering public + admin endpoints
- E2E: 6 Playwright tests covering full game flow including tap-and-hold
- Verified migration runs cleanly on a fresh test DB