### PR TITLE
fix: handle empty response bodies in api() helper

### DIFF
--- a/.claude/context.md
+++ b/.claude/context.md
@@ -266,6 +266,25 @@ CORS, Cloudflare-Konfig, Container-Hardening (read-only FS wo möglich, etc.).
   entweder zurück auf den Feature-Branch oder PR mergen, BEVOR rebuilt
   wird.
 
+- **SQLite-In-Memory in pytest unterscheidet sich von Prod-Postgres**:
+  - `ON DELETE CASCADE` und `ON DELETE SET NULL` werden in SQLite nicht
+    automatisch durchgesetzt (FK-Pragma + ORM-Verhalten weichen ab). Tests, die
+    Cascade-/SET-NULL-Verhalten prüfen, werden mit `@pytest.mark.skip` markiert
+    und stattdessen via `docker-compose.test.yml` gegen frische Postgres
+    verifiziert (Migration läuft auf leerer DB durch).
+  - Boolean-Spalten brauchen NEBEN `server_default="false"` zusätzlich
+    `default=False` (Python-seitig), sonst ist der Initialwert in SQLite-Tests
+    nicht zuverlässig False. Beispiel siehe `RecipeComment.edited` in
+    `models.py`.
+- **Schnell-Iteration im laufenden Backend-Container** (für Tests, ohne
+  Prod-Rebuild): Code-Änderungen direkt rüberkopieren mit
+  `docker cp ~/homepage/backend/<datei> homepage-backend-1:/app/<datei>`,
+  dann `docker compose exec -T backend python -m pytest <pfad> --no-cov`.
+  Achtung: Der laufende Container ist Prod — die kopierten Files sind sofort
+  live, bis der Container neu gebaut wird. Nur für additive/risikofreie
+  Änderungen geeignet (neue Endpoints, Tests). Bei Änderungen an bestehenden
+  Endpoints lieber den Test-Stack nutzen.
+
 ## Prod-Deploy-Disziplin
 
 **Wichtig zum Verständnis**: Es gibt KEIN Auto-Deploy. Ein `git push` auf `main`

--- a/backend/tests/test_recipe_comments.py
+++ b/backend/tests/test_recipe_comments.py
@@ -236,6 +236,9 @@ class TestDeleteComment:
             headers=auth_headers,
         )
         assert response.status_code == 204
+        # Body MUSS leer sein — Frontend-api()-Wrapper würde sonst beim
+        # JSON-Parse einen "Unexpected end of JSON input"-Fehler werfen.
+        assert response.content == b""
         assert db_session.query(models.RecipeComment).filter_by(id=comment_id).first() is None
 
     def test_member_cannot_delete_others(self, client, auth_headers, recipe, db_session):

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -46,5 +46,10 @@ export async function api<T = any>(
     throw new Error(error.detail || 'Fehler');
   }
 
+  // 204 No Content (z.B. DELETE) und andere leere Bodies behandeln —
+  // response.json() würde sonst auf "" einen JSON-Parse-Error werfen.
+  if (response.status === 204 || response.headers.get('content-length') === '0') {
+    return undefined as T;
+  }
   return response.json();
 }


### PR DESCRIPTION
## Was

Der zentrale `api()`-Helper rief `response.json()` unbedingt auf, was bei
204 No Content (z.B. DELETE-Endpoints) einen JSON-Parse-Error warf. Die
UI hat das als generischen Fehler angezeigt, obwohl der Request erfolgreich
war.

**Symptom**: Beim Löschen eines Rezept-Kommentars erschien
`Failed to execute 'json' on 'Response': Unexpected end of JSON input`,
der Kommentar blieb in der UI sichtbar (State wurde nicht aktualisiert),
und ein zweiter Klick auf 'Löschen' führte zu `Kommentar nicht gefunden`
(404 vom Backend, weil der erste Delete tatsächlich durchgegangen war).

## Fix

`api()` returned jetzt `undefined` für HTTP 204 oder `content-length: 0`.
JSON-Parsing nur noch bei Responses mit echtem Body.

## Test

Regression-Assertion in `test_owner_deletes_own` ergänzt: prüft jetzt
explizit dass der DELETE-Response-Body leer ist.

## Wirkung jenseits der Comments

Betrifft alle Endpoints die 204 zurückgeben — derzeit zumindest jeder
DELETE-Endpoint im Repo. Wenn Frontend-Code davon bisher genutzt wurde,
war er auch buggy, ist aber durch optimistische UI oder Auto-Refetch nicht
aufgefallen.