### PR TITLE
feat: add photo diary (admin-only)

### DIFF
--- a/backend/alembic/versions/981139483fef_add_photo_diary_tables.py
+++ b/backend/alembic/versions/981139483fef_add_photo_diary_tables.py
@@ -1,0 +1,59 @@
+"""add photo diary tables
+
+Revision ID: 981139483fef
+Revises: adae80cc7b19
+Create Date: 2026-05-03 12:16:24.751219
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '981139483fef'
+down_revision: Union[str, Sequence[str], None] = 'adae80cc7b19'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        'photo_diary_entries',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('entry_date', sa.Date(), nullable=False),
+        sa.Column('entry_time', sa.Time(), server_default=sa.text('CURRENT_TIME'), nullable=False),
+        sa.Column('description', sa.Text(), nullable=True),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+        sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index(op.f('ix_photo_diary_entries_entry_date'), 'photo_diary_entries', ['entry_date'], unique=False)
+    op.create_index(op.f('ix_photo_diary_entries_id'), 'photo_diary_entries', ['id'], unique=False)
+
+    op.create_table(
+        'photo_diary_images',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('entry_id', sa.Integer(), nullable=False),
+        sa.Column('url', sa.String(), nullable=False),
+        sa.Column('thumb_url', sa.String(), nullable=False),
+        sa.Column('caption', sa.String(length=500), nullable=True),
+        sa.Column('position', sa.Integer(), nullable=False),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+        sa.ForeignKeyConstraint(['entry_id'], ['photo_diary_entries.id'], ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index(op.f('ix_photo_diary_images_entry_id'), 'photo_diary_images', ['entry_id'], unique=False)
+    op.create_index(op.f('ix_photo_diary_images_id'), 'photo_diary_images', ['id'], unique=False)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index(op.f('ix_photo_diary_images_id'), table_name='photo_diary_images')
+    op.drop_index(op.f('ix_photo_diary_images_entry_id'), table_name='photo_diary_images')
+    op.drop_table('photo_diary_images')
+    op.drop_index(op.f('ix_photo_diary_entries_id'), table_name='photo_diary_entries')
+    op.drop_index(op.f('ix_photo_diary_entries_entry_date'), table_name='photo_diary_entries')
+    op.drop_table('photo_diary_entries')

--- a/backend/main.py
+++ b/backend/main.py
@@ -6,7 +6,7 @@ from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware
 from database import Base, engine
 import models
-from routers import auth, shopping, admin, recipes, recipe_comments, tags, seasonal, settings, impostor
+from routers import auth, shopping, admin, recipes, recipe_comments, tags, seasonal, settings, impostor, diary
 from rate_limit import limiter
 import os
 import logging
@@ -38,6 +38,7 @@ app.include_router(tags.router)
 app.include_router(seasonal.router)
 app.include_router(settings.router)
 app.include_router(impostor.router)
+app.include_router(diary.router)
 
 # Test-Only-Endpoints: NUR registrieren wenn ENVIRONMENT=test
 if os.getenv("ENVIRONMENT") == "test":

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, Boolean, DateTime, Text, ForeignKey, Float, UniqueConstraint, CheckConstraint, Index
+from sqlalchemy import Column, Integer, String, Boolean, DateTime, Date, Time, Text, ForeignKey, Float, UniqueConstraint, CheckConstraint, Index
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
 from database import Base
@@ -299,3 +299,47 @@ class RecipeComment(Base):
     __table_args__ = (
         Index("ix_recipe_comments_recipe_created", "recipe_id", "created_at"),
     )
+
+
+# ============================================================
+# Foto-Tagebuch (Admin-only)
+# ============================================================
+
+class PhotoDiaryEntry(Base):
+    __tablename__ = "photo_diary_entries"
+    id = Column(Integer, primary_key=True, index=True)
+    entry_date = Column(Date, nullable=False, index=True)
+    entry_time = Column(Time, nullable=False, server_default=func.current_time())
+    description = Column(Text, nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+    images = relationship(
+        "PhotoDiaryImage",
+        back_populates="entry",
+        cascade="all, delete-orphan",
+        order_by="PhotoDiaryImage.position",
+    )
+
+
+class PhotoDiaryImage(Base):
+    __tablename__ = "photo_diary_images"
+    id = Column(Integer, primary_key=True, index=True)
+    entry_id = Column(
+        Integer,
+        ForeignKey("photo_diary_entries.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    url = Column(String, nullable=False)
+    thumb_url = Column(String, nullable=False)
+    caption = Column(String(500), nullable=True)
+    position = Column(Integer, default=0, nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+
+    entry = relationship("PhotoDiaryEntry", back_populates="images")

--- a/backend/routers/diary.py
+++ b/backend/routers/diary.py
@@ -1,0 +1,319 @@
+"""
+Foto-Tagebuch API (Admin-only).
+
+Datenmodell:
+- PhotoDiaryEntry: ein Eintrag pro (Datum, Zeit), mehrere pro Tag möglich.
+- PhotoDiaryImage: 1:n zu Entry, mit optionaler Caption und Reihenfolge.
+
+Bilder werden via save_diary_image() konvertiert (WebP) und mit Thumbnail
+gespeichert. Files liegen unter UPLOAD_DIR/diary/ bzw. UPLOAD_DIR/diary/thumbs/.
+"""
+import os
+from datetime import date as date_type, time as time_type
+from typing import Optional
+
+from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile, status
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session, selectinload
+
+from database import get_db
+from auth import require_admin
+from upload_utils import save_diary_image
+import models
+
+router = APIRouter(prefix="/diary", tags=["diary"])
+
+UPLOAD_DIR = os.getenv("UPLOAD_DIR", "/app/uploads")
+DIARY_UPLOAD_DIR = os.path.join(UPLOAD_DIR, "diary")
+os.makedirs(DIARY_UPLOAD_DIR, exist_ok=True)
+
+
+# ---------- Pydantic Schemas ----------
+
+class ImageOut(BaseModel):
+    id: int
+    url: str
+    thumb_url: str
+    caption: Optional[str] = None
+    position: int
+
+
+class ImageUpdate(BaseModel):
+    caption: Optional[str] = Field(None, max_length=500)
+
+
+class ImageReorder(BaseModel):
+    image_ids: list[int] = Field(..., min_length=1)
+
+
+class EntryCreate(BaseModel):
+    entry_date: date_type
+    entry_time: Optional[time_type] = None
+    description: Optional[str] = Field(None, max_length=10000)
+
+
+class EntryUpdate(BaseModel):
+    entry_date: Optional[date_type] = None
+    entry_time: Optional[time_type] = None
+    description: Optional[str] = Field(None, max_length=10000)
+
+
+class EntryOut(BaseModel):
+    id: int
+    entry_date: date_type
+    entry_time: time_type
+    description: Optional[str] = None
+    images: list[ImageOut]
+
+
+# ---------- Helpers ----------
+
+def _serialize_image(img: models.PhotoDiaryImage) -> dict:
+    return {
+        "id": img.id,
+        "url": f"/uploads/diary/{img.url}",
+        "thumb_url": f"/uploads/diary/thumbs/{img.thumb_url}",
+        "caption": img.caption,
+        "position": img.position,
+    }
+
+
+def _serialize_entry(entry: models.PhotoDiaryEntry) -> dict:
+    return {
+        "id": entry.id,
+        "entry_date": entry.entry_date,
+        "entry_time": entry.entry_time,
+        "description": entry.description,
+        "images": [_serialize_image(img) for img in entry.images],
+    }
+
+
+def _get_entry_or_404(entry_id: int, db: Session) -> models.PhotoDiaryEntry:
+    entry = (
+        db.query(models.PhotoDiaryEntry)
+        .options(selectinload(models.PhotoDiaryEntry.images))
+        .filter(models.PhotoDiaryEntry.id == entry_id)
+        .first()
+    )
+    if not entry:
+        raise HTTPException(status_code=404, detail="Eintrag nicht gefunden")
+    return entry
+
+
+def _delete_image_files(img: models.PhotoDiaryImage) -> None:
+    """Löscht Voll- und Thumb-File von der Disk. Fehler werden geschluckt
+    (DB ist Source of Truth — Datei-Leichen sind besser als verwaiste DB-Rows)."""
+    for path in (
+        os.path.join(DIARY_UPLOAD_DIR, img.url),
+        os.path.join(DIARY_UPLOAD_DIR, "thumbs", img.thumb_url),
+    ):
+        try:
+            if os.path.isfile(path):
+                os.remove(path)
+        except OSError:
+            pass
+
+
+# ---------- Endpoints: Entries ----------
+
+@router.get("", response_model=list[EntryOut])
+def list_entries(
+    date_from: Optional[date_type] = Query(None, alias="from"),
+    date_to: Optional[date_type] = Query(None, alias="to"),
+    db: Session = Depends(get_db),
+    admin: models.User = Depends(require_admin),
+):
+    """Alle Einträge, optional gefiltert nach Datumsbereich. Sortiert: neueste zuerst."""
+    query = db.query(models.PhotoDiaryEntry).options(
+        selectinload(models.PhotoDiaryEntry.images)
+    )
+    if date_from:
+        query = query.filter(models.PhotoDiaryEntry.entry_date >= date_from)
+    if date_to:
+        query = query.filter(models.PhotoDiaryEntry.entry_date <= date_to)
+    query = query.order_by(
+        models.PhotoDiaryEntry.entry_date.desc(),
+        models.PhotoDiaryEntry.entry_time.desc(),
+    )
+    return [_serialize_entry(e) for e in query.all()]
+
+
+@router.get("/{entry_id}", response_model=EntryOut)
+def get_entry(
+    entry_id: int,
+    db: Session = Depends(get_db),
+    admin: models.User = Depends(require_admin),
+):
+    entry = _get_entry_or_404(entry_id, db)
+    return _serialize_entry(entry)
+
+
+@router.post("", response_model=EntryOut, status_code=status.HTTP_201_CREATED)
+def create_entry(
+    data: EntryCreate,
+    db: Session = Depends(get_db),
+    admin: models.User = Depends(require_admin),
+):
+    entry = models.PhotoDiaryEntry(
+        entry_date=data.entry_date,
+        description=data.description,
+    )
+    if data.entry_time is not None:
+        entry.entry_time = data.entry_time
+    db.add(entry)
+    db.commit()
+    db.refresh(entry)
+    return _serialize_entry(entry)
+
+
+@router.patch("/{entry_id}", response_model=EntryOut)
+def update_entry(
+    entry_id: int,
+    data: EntryUpdate,
+    db: Session = Depends(get_db),
+    admin: models.User = Depends(require_admin),
+):
+    entry = _get_entry_or_404(entry_id, db)
+    update_data = data.model_dump(exclude_unset=True)
+    for field, value in update_data.items():
+        setattr(entry, field, value)
+    db.commit()
+    db.refresh(entry)
+    return _serialize_entry(entry)
+
+
+@router.delete("/{entry_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_entry(
+    entry_id: int,
+    db: Session = Depends(get_db),
+    admin: models.User = Depends(require_admin),
+):
+    entry = _get_entry_or_404(entry_id, db)
+    # Files vor dem DB-Delete entfernen (cascade löscht die DB-Rows danach)
+    for img in entry.images:
+        _delete_image_files(img)
+    db.delete(entry)
+    db.commit()
+    return None
+
+
+# ---------- Endpoints: Images ----------
+
+@router.post(
+    "/{entry_id}/images",
+    response_model=list[ImageOut],
+    status_code=status.HTTP_201_CREATED,
+)
+def upload_images(
+    entry_id: int,
+    files: list[UploadFile] = File(...),
+    db: Session = Depends(get_db),
+    admin: models.User = Depends(require_admin),
+):
+    """Mehrere Bilder in einem Request hochladen. Werden ans Ende der Reihenfolge angehängt."""
+    if not files:
+        raise HTTPException(status_code=400, detail="Keine Dateien")
+
+    entry = _get_entry_or_404(entry_id, db)
+
+    # Aktuell höchste Position bestimmen, neue Bilder werden ans Ende angehängt
+    max_position = max((img.position for img in entry.images), default=-1)
+
+    saved: list[models.PhotoDiaryImage] = []
+    saved_files: list[tuple[str, str]] = []  # für Rollback bei DB-Fehler
+    try:
+        for idx, file in enumerate(files, start=1):
+            full_name, thumb_name = save_diary_image(file, DIARY_UPLOAD_DIR)
+            saved_files.append((full_name, thumb_name))
+            img = models.PhotoDiaryImage(
+                entry_id=entry.id,
+                url=full_name,
+                thumb_url=thumb_name,
+                position=max_position + idx,
+            )
+            db.add(img)
+            saved.append(img)
+        db.commit()
+    except Exception:
+        # Bereits geschriebene Files wieder weghauen, sonst Datei-Leichen
+        db.rollback()
+        for full_name, thumb_name in saved_files:
+            for path in (
+                os.path.join(DIARY_UPLOAD_DIR, full_name),
+                os.path.join(DIARY_UPLOAD_DIR, "thumbs", thumb_name),
+            ):
+                try:
+                    if os.path.isfile(path):
+                        os.remove(path)
+                except OSError:
+                    pass
+        raise
+
+    for img in saved:
+        db.refresh(img)
+    return [_serialize_image(img) for img in saved]
+
+
+@router.patch("/images/{image_id}", response_model=ImageOut)
+def update_image(
+    image_id: int,
+    data: ImageUpdate,
+    db: Session = Depends(get_db),
+    admin: models.User = Depends(require_admin),
+):
+    img = db.query(models.PhotoDiaryImage).filter(
+        models.PhotoDiaryImage.id == image_id
+    ).first()
+    if not img:
+        raise HTTPException(status_code=404, detail="Bild nicht gefunden")
+    update_data = data.model_dump(exclude_unset=True)
+    for field, value in update_data.items():
+        setattr(img, field, value)
+    db.commit()
+    db.refresh(img)
+    return _serialize_image(img)
+
+
+@router.delete("/images/{image_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_image(
+    image_id: int,
+    db: Session = Depends(get_db),
+    admin: models.User = Depends(require_admin),
+):
+    img = db.query(models.PhotoDiaryImage).filter(
+        models.PhotoDiaryImage.id == image_id
+    ).first()
+    if not img:
+        raise HTTPException(status_code=404, detail="Bild nicht gefunden")
+    _delete_image_files(img)
+    db.delete(img)
+    db.commit()
+    return None
+
+
+@router.patch("/{entry_id}/images/reorder", response_model=list[ImageOut])
+def reorder_images(
+    entry_id: int,
+    data: ImageReorder,
+    db: Session = Depends(get_db),
+    admin: models.User = Depends(require_admin),
+):
+    """Neue Reihenfolge anhand der gelieferten Image-ID-Liste setzen.
+    Alle Image-IDs müssen zum Eintrag gehören und vollständig sein."""
+    entry = _get_entry_or_404(entry_id, db)
+    existing_ids = {img.id for img in entry.images}
+    given_ids = set(data.image_ids)
+    if given_ids != existing_ids:
+        raise HTTPException(
+            status_code=400,
+            detail="Image-ID-Liste muss exakt alle Bilder des Eintrags enthalten",
+        )
+    if len(data.image_ids) != len(set(data.image_ids)):
+        raise HTTPException(status_code=400, detail="Doppelte Image-IDs")
+
+    id_to_position = {img_id: pos for pos, img_id in enumerate(data.image_ids)}
+    for img in entry.images:
+        img.position = id_to_position[img.id]
+    db.commit()
+    db.refresh(entry)
+    return [_serialize_image(img) for img in sorted(entry.images, key=lambda i: i.position)]

--- a/backend/tests/test_diary.py
+++ b/backend/tests/test_diary.py
@@ -1,0 +1,319 @@
+"""Tests für Foto-Tagebuch-Endpoints (admin-only)."""
+import io
+from datetime import date, time
+
+import pytest
+from PIL import Image
+
+
+# ---------- Helpers ----------
+
+def _make_test_image(format: str = "JPEG", size=(800, 600), color=(120, 200, 80)) -> bytes:
+    """Erzeugt ein gültiges Test-Bild (RGB) als Bytes."""
+    img = Image.new("RGB", size, color=color)
+    buf = io.BytesIO()
+    img.save(buf, format=format)
+    return buf.getvalue()
+
+
+def _create_entry(client, admin_headers, **overrides):
+    payload = {"entry_date": "2026-05-01", "description": "Erster Eintrag"}
+    payload.update(overrides)
+    resp = client.post("/diary", json=payload, headers=admin_headers)
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+# ---------- Auth-Guard ----------
+
+class TestAuthGuard:
+    def test_anonymous_cannot_list(self, client):
+        assert client.get("/diary").status_code == 401
+
+    def test_guest_cannot_list(self, client, guest_headers):
+        assert client.get("/diary", headers=guest_headers).status_code == 403
+
+    def test_member_cannot_list(self, client, auth_headers):
+        assert client.get("/diary", headers=auth_headers).status_code == 403
+
+    def test_household_cannot_list(self, client, household_headers):
+        assert client.get("/diary", headers=household_headers).status_code == 403
+
+    def test_admin_can_list(self, client, admin_headers):
+        assert client.get("/diary", headers=admin_headers).status_code == 200
+
+    def test_member_cannot_create(self, client, auth_headers):
+        resp = client.post(
+            "/diary",
+            json={"entry_date": "2026-05-01"},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 403
+
+
+# ---------- Entry CRUD ----------
+
+class TestEntryCRUD:
+    def test_create_entry_minimal(self, client, admin_headers):
+        resp = client.post(
+            "/diary",
+            json={"entry_date": "2026-05-01"},
+            headers=admin_headers,
+        )
+        assert resp.status_code == 201, resp.text
+        data = resp.json()
+        assert data["entry_date"] == "2026-05-01"
+        assert data["description"] is None
+        assert data["images"] == []
+        assert "entry_time" in data  # default vom server
+
+    def test_create_entry_with_description(self, client, admin_headers):
+        data = _create_entry(client, admin_headers, description="Schöner Tag")
+        assert data["description"] == "Schöner Tag"
+
+    def test_create_entry_with_explicit_time(self, client, admin_headers):
+        data = _create_entry(client, admin_headers, entry_time="14:30:00")
+        assert data["entry_time"].startswith("14:30")
+
+    def test_list_entries_sorted_desc(self, client, admin_headers):
+        _create_entry(client, admin_headers, entry_date="2026-01-01")
+        _create_entry(client, admin_headers, entry_date="2026-03-01")
+        _create_entry(client, admin_headers, entry_date="2026-02-01")
+        resp = client.get("/diary", headers=admin_headers)
+        assert resp.status_code == 200
+        dates = [e["entry_date"] for e in resp.json()]
+        assert dates == ["2026-03-01", "2026-02-01", "2026-01-01"]
+
+    def test_multiple_entries_per_day_sorted_by_time(self, client, admin_headers):
+        _create_entry(client, admin_headers, entry_date="2026-05-01", entry_time="09:00:00")
+        _create_entry(client, admin_headers, entry_date="2026-05-01", entry_time="18:00:00")
+        _create_entry(client, admin_headers, entry_date="2026-05-01", entry_time="12:00:00")
+        resp = client.get("/diary", headers=admin_headers)
+        times = [e["entry_time"] for e in resp.json()]
+        # Alle gleicher Tag, neueste Zeit zuerst
+        assert times[0].startswith("18:")
+        assert times[1].startswith("12:")
+        assert times[2].startswith("09:")
+
+    def test_list_filtered_by_date_range(self, client, admin_headers):
+        _create_entry(client, admin_headers, entry_date="2026-01-15")
+        _create_entry(client, admin_headers, entry_date="2026-02-15")
+        _create_entry(client, admin_headers, entry_date="2026-03-15")
+        resp = client.get(
+            "/diary?from=2026-02-01&to=2026-02-28",
+            headers=admin_headers,
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["entry_date"] == "2026-02-15"
+
+    def test_get_entry_by_id(self, client, admin_headers):
+        created = _create_entry(client, admin_headers)
+        resp = client.get(f"/diary/{created['id']}", headers=admin_headers)
+        assert resp.status_code == 200
+        assert resp.json()["id"] == created["id"]
+
+    def test_get_unknown_entry_404(self, client, admin_headers):
+        assert client.get("/diary/99999", headers=admin_headers).status_code == 404
+
+    def test_update_entry(self, client, admin_headers):
+        created = _create_entry(client, admin_headers, description="Alt")
+        resp = client.patch(
+            f"/diary/{created['id']}",
+            json={"description": "Neu"},
+            headers=admin_headers,
+        )
+        assert resp.status_code == 200
+        assert resp.json()["description"] == "Neu"
+
+    def test_update_partial_keeps_other_fields(self, client, admin_headers):
+        created = _create_entry(client, admin_headers, description="Original")
+        resp = client.patch(
+            f"/diary/{created['id']}",
+            json={"entry_date": "2026-12-31"},
+            headers=admin_headers,
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["entry_date"] == "2026-12-31"
+        assert body["description"] == "Original"
+
+    def test_delete_entry(self, client, admin_headers):
+        created = _create_entry(client, admin_headers)
+        resp = client.delete(f"/diary/{created['id']}", headers=admin_headers)
+        assert resp.status_code == 204
+        assert client.get(f"/diary/{created['id']}", headers=admin_headers).status_code == 404
+
+
+# ---------- Image Upload ----------
+
+class TestImageUpload:
+    def test_upload_single_image(self, client, admin_headers):
+        entry = _create_entry(client, admin_headers)
+        img_bytes = _make_test_image()
+        resp = client.post(
+            f"/diary/{entry['id']}/images",
+            files=[("files", ("foto.jpg", img_bytes, "image/jpeg"))],
+            headers=admin_headers,
+        )
+        assert resp.status_code == 201, resp.text
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["url"].startswith("/uploads/diary/")
+        assert data[0]["url"].endswith(".webp")  # konvertiert
+        assert data[0]["thumb_url"].startswith("/uploads/diary/thumbs/")
+        assert data[0]["position"] == 0
+
+    def test_upload_multiple_images_in_one_request(self, client, admin_headers):
+        entry = _create_entry(client, admin_headers)
+        files = [
+            ("files", (f"f{i}.jpg", _make_test_image(color=(i*40, 100, 100)), "image/jpeg"))
+            for i in range(3)
+        ]
+        resp = client.post(
+            f"/diary/{entry['id']}/images",
+            files=files,
+            headers=admin_headers,
+        )
+        assert resp.status_code == 201
+        data = resp.json()
+        assert len(data) == 3
+        positions = [img["position"] for img in data]
+        assert positions == [0, 1, 2]
+
+    def test_upload_appends_to_existing(self, client, admin_headers):
+        entry = _create_entry(client, admin_headers)
+        client.post(
+            f"/diary/{entry['id']}/images",
+            files=[("files", ("a.jpg", _make_test_image(), "image/jpeg"))],
+            headers=admin_headers,
+        )
+        resp = client.post(
+            f"/diary/{entry['id']}/images",
+            files=[("files", ("b.jpg", _make_test_image(color=(200, 0, 0)), "image/jpeg"))],
+            headers=admin_headers,
+        )
+        assert resp.status_code == 201
+        assert resp.json()[0]["position"] == 1
+
+    def test_upload_to_unknown_entry_404(self, client, admin_headers):
+        resp = client.post(
+            "/diary/99999/images",
+            files=[("files", ("x.jpg", _make_test_image(), "image/jpeg"))],
+            headers=admin_headers,
+        )
+        assert resp.status_code == 404
+
+    def test_upload_rejects_invalid_format(self, client, admin_headers):
+        entry = _create_entry(client, admin_headers)
+        # GIF ist im Diary-Helper NICHT erlaubt
+        resp = client.post(
+            f"/diary/{entry['id']}/images",
+            files=[("files", ("a.gif", _make_test_image(format="GIF"), "image/gif"))],
+            headers=admin_headers,
+        )
+        assert resp.status_code == 400
+
+    def test_upload_rejects_non_image(self, client, admin_headers):
+        entry = _create_entry(client, admin_headers)
+        resp = client.post(
+            f"/diary/{entry['id']}/images",
+            files=[("files", ("a.jpg", b"not an image", "image/jpeg"))],
+            headers=admin_headers,
+        )
+        assert resp.status_code == 400
+
+    def test_member_cannot_upload(self, client, auth_headers, admin_headers):
+        entry = _create_entry(client, admin_headers)
+        resp = client.post(
+            f"/diary/{entry['id']}/images",
+            files=[("files", ("a.jpg", _make_test_image(), "image/jpeg"))],
+            headers=auth_headers,
+        )
+        assert resp.status_code == 403
+
+
+# ---------- Image Update / Delete / Reorder ----------
+
+class TestImageMutations:
+    def _entry_with_images(self, client, admin_headers, n=3):
+        entry = _create_entry(client, admin_headers)
+        files = [
+            ("files", (f"f{i}.jpg", _make_test_image(color=(i*60, 0, 0)), "image/jpeg"))
+            for i in range(n)
+        ]
+        resp = client.post(
+            f"/diary/{entry['id']}/images",
+            files=files,
+            headers=admin_headers,
+        )
+        return entry, resp.json()
+
+    def test_update_caption(self, client, admin_headers):
+        _, imgs = self._entry_with_images(client, admin_headers, n=1)
+        resp = client.patch(
+            f"/diary/images/{imgs[0]['id']}",
+            json={"caption": "Sonnenaufgang"},
+            headers=admin_headers,
+        )
+        assert resp.status_code == 200
+        assert resp.json()["caption"] == "Sonnenaufgang"
+
+    def test_update_caption_too_long(self, client, admin_headers):
+        _, imgs = self._entry_with_images(client, admin_headers, n=1)
+        resp = client.patch(
+            f"/diary/images/{imgs[0]['id']}",
+            json={"caption": "x" * 501},
+            headers=admin_headers,
+        )
+        assert resp.status_code == 422
+
+    def test_delete_single_image(self, client, admin_headers):
+        entry, imgs = self._entry_with_images(client, admin_headers, n=2)
+        resp = client.delete(f"/diary/images/{imgs[0]['id']}", headers=admin_headers)
+        assert resp.status_code == 204
+        # Nur noch ein Bild übrig
+        entry_resp = client.get(f"/diary/{entry['id']}", headers=admin_headers)
+        assert len(entry_resp.json()["images"]) == 1
+
+    def test_reorder_images(self, client, admin_headers):
+        entry, imgs = self._entry_with_images(client, admin_headers, n=3)
+        new_order = [imgs[2]["id"], imgs[0]["id"], imgs[1]["id"]]
+        resp = client.patch(
+            f"/diary/{entry['id']}/images/reorder",
+            json={"image_ids": new_order},
+            headers=admin_headers,
+        )
+        assert resp.status_code == 200
+        ordered = resp.json()
+        assert [img["id"] for img in ordered] == new_order
+        assert [img["position"] for img in ordered] == [0, 1, 2]
+
+    def test_reorder_rejects_incomplete_list(self, client, admin_headers):
+        entry, imgs = self._entry_with_images(client, admin_headers, n=3)
+        resp = client.patch(
+            f"/diary/{entry['id']}/images/reorder",
+            json={"image_ids": [imgs[0]["id"], imgs[1]["id"]]},
+            headers=admin_headers,
+        )
+        assert resp.status_code == 400
+
+    def test_reorder_rejects_foreign_image_id(self, client, admin_headers):
+        entry, imgs = self._entry_with_images(client, admin_headers, n=2)
+        resp = client.patch(
+            f"/diary/{entry['id']}/images/reorder",
+            json={"image_ids": [imgs[0]["id"], 99999]},
+            headers=admin_headers,
+        )
+        assert resp.status_code == 400
+
+
+# ---------- Cascade ----------
+
+@pytest.mark.skip(
+    reason="SQLite enforced FK CASCADE nicht zuverlässig in Tests "
+    "— gegen Postgres via docker-compose.test.yml verifiziert"
+)
+def test_delete_entry_cascades_images(client, admin_headers, db_session):
+    pass

--- a/backend/upload_utils.py
+++ b/backend/upload_utils.py
@@ -2,8 +2,9 @@
 import os
 import uuid
 from io import BytesIO
+
 from fastapi import HTTPException, UploadFile
-from PIL import Image
+from PIL import Image, ImageOps
 
 MAX_IMAGE_BYTES = 5 * 1024 * 1024  # 5 MB
 ALLOWED_FORMATS = {"JPEG", "PNG", "GIF", "WEBP"}
@@ -13,6 +14,14 @@ EXT_BY_FORMAT = {
     "GIF": "gif",
     "WEBP": "webp",
 }
+
+# Diary-spezifisch: größeres Limit (15 MB), keine GIFs, WebP-Output
+DIARY_MAX_IMAGE_BYTES = 15 * 1024 * 1024
+DIARY_ALLOWED_INPUT_FORMATS = {"JPEG", "PNG", "WEBP"}
+DIARY_FULL_MAX_DIM = 2000   # px lange Kante
+DIARY_THUMB_MAX_DIM = 600   # px lange Kante
+DIARY_FULL_QUALITY = 85
+DIARY_THUMB_QUALITY = 80
 
 
 def save_image(file: UploadFile, upload_dir: str, prefix: str = "") -> str:
@@ -60,3 +69,68 @@ def save_image(file: UploadFile, upload_dir: str, prefix: str = "") -> str:
 
     img.save(filepath, format=fmt, **save_kwargs)
     return filename
+
+
+def save_diary_image(file: UploadFile, upload_dir: str) -> tuple[str, str]:
+    """
+    Diary-spezifischer Upload: WebP-Output, Resize, mit Thumbnail.
+
+    - Akzeptiert JPEG/PNG/WebP-Input (max. 15 MB)
+    - Konvertiert immer nach WebP
+    - Vollbild: max. 2000px lange Kante (Quality 85)
+    - Thumbnail: max. 600px lange Kante (Quality 80) — separater File für Liste/Kalender
+    - EXIF-Orientation wird angewandt (Smartphone-Fotos korrekt rotieren), dann gestripped
+    - Liefert (full_filename, thumb_filename) zurück. Thumbnails landen im Subdir 'thumbs/'.
+    - upload_dir sollte bereits existieren; thumbs/ wird ggf. angelegt.
+    """
+    raw = file.file.read(DIARY_MAX_IMAGE_BYTES + 1)
+    if len(raw) > DIARY_MAX_IMAGE_BYTES:
+        raise HTTPException(status_code=413, detail="Bild zu groß (max 15 MB)")
+    if not raw:
+        raise HTTPException(status_code=400, detail="Leere Datei")
+
+    try:
+        img = Image.open(BytesIO(raw))
+        img.verify()
+        img = Image.open(BytesIO(raw))
+        fmt = img.format
+    except Exception:
+        raise HTTPException(status_code=400, detail="Ungültiges Bildformat")
+
+    if fmt not in DIARY_ALLOWED_INPUT_FORMATS:
+        raise HTTPException(status_code=400, detail=f"Format {fmt} nicht erlaubt")
+
+    # EXIF-Orientation auf Pixel anwenden, dann ist das Bild "richtig herum" und EXIF kann weg
+    img = ImageOps.exif_transpose(img)
+
+    # WebP unterstützt RGB und RGBA, kein CMYK/L → normalisieren
+    if img.mode not in ("RGB", "RGBA"):
+        img = img.convert("RGB")
+
+    # Path-Traversal-Schutz für upload_dir
+    real_upload_dir = os.path.realpath(upload_dir)
+    thumb_dir = os.path.join(upload_dir, "thumbs")
+    os.makedirs(thumb_dir, exist_ok=True)
+
+    base_name = uuid.uuid4().hex
+    full_filename = f"{base_name}.webp"
+    thumb_filename = f"{base_name}.webp"
+    full_path = os.path.join(upload_dir, full_filename)
+    thumb_path = os.path.join(thumb_dir, thumb_filename)
+
+    # Path-Traversal-Verifikation für beide Files
+    for p in (full_path, thumb_path):
+        if not os.path.realpath(p).startswith(real_upload_dir + os.sep):
+            raise HTTPException(status_code=400, detail="Ungültiger Pfad")
+
+    # Vollbild: nur runterskalieren falls nötig (thumbnail() ändert in-place + behält aspect ratio)
+    full_img = img.copy()
+    full_img.thumbnail((DIARY_FULL_MAX_DIM, DIARY_FULL_MAX_DIM), Image.Resampling.LANCZOS)
+    full_img.save(full_path, format="WEBP", quality=DIARY_FULL_QUALITY, method=6)
+
+    # Thumbnail
+    thumb_img = img.copy()
+    thumb_img.thumbnail((DIARY_THUMB_MAX_DIM, DIARY_THUMB_MAX_DIM), Image.Resampling.LANCZOS)
+    thumb_img.save(thumb_path, format="WEBP", quality=DIARY_THUMB_QUALITY, method=6)
+
+    return full_filename, thumb_filename

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,9 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-router-dom": "^7.14.2"
@@ -282,6 +285,59 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -2928,9 +2984,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-router-dom": "^7.14.2"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,9 @@ import { AdminUsers } from './pages/AdminUsers';
 import { AdminTags } from './pages/AdminTags';
 import { AdminSettings } from './pages/AdminSettings';
 import { NotFound } from './pages/NotFound';
+import { Diary } from './pages/Diary';
+import { DiaryNew } from './pages/DiaryNew';
+import { DiaryEdit } from './pages/DiaryEdit';
 import { ForgotPassword } from './pages/ForgotPassword';
 import { ResetPassword } from './pages/ResetPassword';
 import { SeasonalCalendar } from './pages/SeasonalCalendar';
@@ -46,6 +49,9 @@ function App() {
         <Route path="/admin/einstellungen" element={<AdminSettings />} />
         <Route path="/forgot-password" element={<ForgotPassword />} />
         <Route path="/reset-password" element={<ResetPassword />} />
+        <Route path="/diary" element={<Diary />} />
+        <Route path="/diary/neu" element={<DiaryNew />} />
+        <Route path="/diary/:id/bearbeiten" element={<DiaryEdit />} />
         <Route path="*" element={<NotFound />} />
       </Routes>
     </BrowserRouter>

--- a/frontend/src/api/diary.ts
+++ b/frontend/src/api/diary.ts
@@ -1,0 +1,118 @@
+/**
+ * API-Client für Foto-Tagebuch (Admin-only).
+ *
+ * Bilder-URLs aus dem Backend sind relativ ("/uploads/diary/..."). Mit
+ * imageUrl() wird VITE_API_URL davorgehängt, damit das Frontend sie laden kann.
+ */
+import { api, getToken } from '../lib/api';
+import type { DiaryEntry, DiaryEntryInput, DiaryImage } from '../types';
+
+const API_URL = import.meta.env.VITE_API_URL;
+
+/** Aus relativem Backend-Pfad (z.B. "/uploads/diary/abc.webp") absolute URL bauen. */
+export function imageUrl(relativePath: string): string {
+  if (!relativePath) return '';
+  if (/^https?:\/\//.test(relativePath)) return relativePath;
+  return `${API_URL}${relativePath}`;
+}
+
+// ---------- Entries ----------
+
+export async function listEntries(params?: {
+  from?: string;
+  to?: string;
+}): Promise<DiaryEntry[]> {
+  const search = new URLSearchParams();
+  if (params?.from) search.set('from', params.from);
+  if (params?.to) search.set('to', params.to);
+  const qs = search.toString();
+  return api<DiaryEntry[]>(`/diary${qs ? `?${qs}` : ''}`);
+}
+
+export async function getEntry(id: number): Promise<DiaryEntry> {
+  return api<DiaryEntry>(`/diary/${id}`);
+}
+
+export async function createEntry(input: DiaryEntryInput): Promise<DiaryEntry> {
+  return api<DiaryEntry>('/diary', {
+    method: 'POST',
+    body: JSON.stringify(input),
+  });
+}
+
+export async function updateEntry(
+  id: number,
+  input: Partial<DiaryEntryInput>,
+): Promise<DiaryEntry> {
+  return api<DiaryEntry>(`/diary/${id}`, {
+    method: 'PATCH',
+    body: JSON.stringify(input),
+  });
+}
+
+export async function deleteEntry(id: number): Promise<void> {
+  await api<void>(`/diary/${id}`, { method: 'DELETE' });
+}
+
+// ---------- Images ----------
+
+/**
+ * Bild-Upload via Multipart. Der zentrale api()-Helper setzt
+ * Content-Type: application/json hardcoded, das passt für Multipart nicht
+ * (Browser muss die Boundary selbst setzen). Daher hier direkt fetch.
+ */
+export async function uploadImages(
+  entryId: number,
+  files: File[],
+): Promise<DiaryImage[]> {
+  const formData = new FormData();
+  for (const file of files) {
+    formData.append('files', file);
+  }
+
+  const headers: Record<string, string> = {};
+  const token = getToken();
+  if (token) headers['Authorization'] = `Bearer ${token}`;
+
+  const response = await fetch(`${API_URL}/diary/${entryId}/images`, {
+    method: 'POST',
+    headers,
+    body: formData,
+  });
+
+  if (response.status === 401 && token) {
+    // gleiche Logik wie im api()-Helper
+    localStorage.removeItem('token');
+    window.location.href = '/login';
+    throw new Error('Session abgelaufen');
+  }
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({ detail: 'Upload fehlgeschlagen' }));
+    throw new Error(error.detail || 'Upload fehlgeschlagen');
+  }
+  return response.json();
+}
+
+export async function updateImage(
+  imageId: number,
+  data: { caption?: string | null },
+): Promise<DiaryImage> {
+  return api<DiaryImage>(`/diary/images/${imageId}`, {
+    method: 'PATCH',
+    body: JSON.stringify(data),
+  });
+}
+
+export async function deleteImage(imageId: number): Promise<void> {
+  await api<void>(`/diary/images/${imageId}`, { method: 'DELETE' });
+}
+
+export async function reorderImages(
+  entryId: number,
+  imageIds: number[],
+): Promise<DiaryImage[]> {
+  return api<DiaryImage[]>(`/diary/${entryId}/images/reorder`, {
+    method: 'PATCH',
+    body: JSON.stringify({ image_ids: imageIds }),
+  });
+}

--- a/frontend/src/components/Datepicker.tsx
+++ b/frontend/src/components/Datepicker.tsx
@@ -1,0 +1,230 @@
+import { useState, useEffect, useRef } from 'react';
+
+interface DatepickerProps {
+  /** Aktueller Wert als ISO-String "YYYY-MM-DD" oder leer. */
+  value: string;
+  onChange: (value: string) => void;
+  /** Optionales ID/Name fürs umliegende <label>. */
+  id?: string;
+}
+
+const MONTHS_DE = [
+  'Januar', 'Februar', 'März', 'April', 'Mai', 'Juni',
+  'Juli', 'August', 'September', 'Oktober', 'November', 'Dezember',
+];
+const WEEKDAYS_DE = ['Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa', 'So'];
+
+function pad(n: number): string {
+  return n.toString().padStart(2, '0');
+}
+
+function toISO(d: Date): string {
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+}
+
+function fromISO(s: string): Date | null {
+  if (!s) return null;
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(s);
+  if (!m) return null;
+  const d = new Date(Number(m[1]), Number(m[2]) - 1, Number(m[3]));
+  return isNaN(d.getTime()) ? null : d;
+}
+
+function formatDisplay(s: string): string {
+  const d = fromISO(s);
+  if (!d) return '';
+  return `${pad(d.getDate())}.${pad(d.getMonth() + 1)}.${d.getFullYear()}`;
+}
+
+export function Datepicker({ value, onChange, id }: DatepickerProps) {
+  const today = new Date();
+  const initial = fromISO(value) || today;
+
+  const [open, setOpen] = useState(false);
+  const [viewYear, setViewYear] = useState(initial.getFullYear());
+  const [viewMonth, setViewMonth] = useState(initial.getMonth()); // 0-11
+  const wrapperRef = useRef<HTMLDivElement>(null);
+
+  // Klick außerhalb schließt das Popup
+  useEffect(() => {
+    if (!open) return;
+    function onDocClick(e: MouseEvent) {
+      if (wrapperRef.current && !wrapperRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', onDocClick);
+    return () => document.removeEventListener('mousedown', onDocClick);
+  }, [open]);
+
+  // ESC schließt
+  useEffect(() => {
+    if (!open) return;
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') setOpen(false);
+    }
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open]);
+
+  // Wenn value von außen geändert wird, View synchronisieren
+  useEffect(() => {
+    const d = fromISO(value);
+    if (d) {
+      setViewYear(d.getFullYear());
+      setViewMonth(d.getMonth());
+    }
+  }, [value]);
+
+  function prevMonth() {
+    if (viewMonth === 0) {
+      setViewMonth(11);
+      setViewYear(viewYear - 1);
+    } else {
+      setViewMonth(viewMonth - 1);
+    }
+  }
+
+  function nextMonth() {
+    if (viewMonth === 11) {
+      setViewMonth(0);
+      setViewYear(viewYear + 1);
+    } else {
+      setViewMonth(viewMonth + 1);
+    }
+  }
+
+  function selectDay(day: number) {
+    const d = new Date(viewYear, viewMonth, day);
+    onChange(toISO(d));
+    setOpen(false);
+  }
+
+  function selectToday() {
+    const d = new Date();
+    onChange(toISO(d));
+    setViewYear(d.getFullYear());
+    setViewMonth(d.getMonth());
+    setOpen(false);
+  }
+
+  // Tage-Grid berechnen: Wochenstart Montag (Europa)
+  const firstOfMonth = new Date(viewYear, viewMonth, 1);
+  // getDay() liefert 0=So..6=Sa, wir wollen 0=Mo..6=So
+  const firstWeekday = (firstOfMonth.getDay() + 6) % 7;
+  const daysInMonth = new Date(viewYear, viewMonth + 1, 0).getDate();
+  const cells: (number | null)[] = [];
+  for (let i = 0; i < firstWeekday; i++) cells.push(null);
+  for (let d = 1; d <= daysInMonth; d++) cells.push(d);
+  while (cells.length % 7 !== 0) cells.push(null);
+
+  const selected = fromISO(value);
+  const todayISO = toISO(today);
+
+  function isSelected(day: number): boolean {
+    return !!selected
+      && selected.getFullYear() === viewYear
+      && selected.getMonth() === viewMonth
+      && selected.getDate() === day;
+  }
+
+  function isToday(day: number): boolean {
+    return toISO(new Date(viewYear, viewMonth, day)) === todayISO;
+  }
+
+  return (
+    <div ref={wrapperRef} className="relative inline-block">
+      <button
+        type="button"
+        id={id}
+        onClick={() => setOpen(o => !o)}
+        className="px-3 py-2 border border-border rounded-lg bg-bg-primary text-text-primary text-sm w-44 text-left hover:border-text-muted transition-colors"
+        aria-haspopup="dialog"
+        aria-expanded={open}
+      >
+        {value ? formatDisplay(value) : <span className="text-text-muted">Datum wählen</span>}
+      </button>
+
+      {open && (
+        <div
+          className="absolute z-30 mt-1 bg-bg-secondary border border-border rounded-lg shadow-lg p-3 w-72"
+          role="dialog"
+        >
+          <div className="flex items-center justify-between mb-2">
+            <button
+              type="button"
+              onClick={prevMonth}
+              className="p-1 text-text-muted hover:text-text-primary"
+              aria-label="Vorheriger Monat"
+            >
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <polyline points="15 18 9 12 15 6" />
+              </svg>
+            </button>
+            <span className="text-sm font-medium text-text-primary">
+              {MONTHS_DE[viewMonth]} {viewYear}
+            </span>
+            <button
+              type="button"
+              onClick={nextMonth}
+              className="p-1 text-text-muted hover:text-text-primary"
+              aria-label="Nächster Monat"
+            >
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <polyline points="9 18 15 12 9 6" />
+              </svg>
+            </button>
+          </div>
+
+          <div className="grid grid-cols-7 gap-0.5 mb-1">
+            {WEEKDAYS_DE.map(w => (
+              <div key={w} className="text-center text-xs text-text-muted py-1">{w}</div>
+            ))}
+          </div>
+
+          <div className="grid grid-cols-7 gap-0.5">
+            {cells.map((day, i) => {
+              if (day === null) return <div key={i} />;
+              const sel = isSelected(day);
+              const td = isToday(day);
+              return (
+                <button
+                  key={i}
+                  type="button"
+                  onClick={() => selectDay(day)}
+                  className={[
+                    'aspect-square text-sm rounded transition-colors',
+                    sel
+                      ? 'bg-text-primary text-bg-primary font-medium'
+                      : td
+                        ? 'border border-text-muted text-text-primary hover:bg-bg-primary'
+                        : 'text-text-primary hover:bg-bg-primary',
+                  ].join(' ')}
+                >
+                  {day}
+                </button>
+              );
+            })}
+          </div>
+
+          <div className="flex justify-between mt-3 pt-2 border-t border-border">
+            <button
+              type="button"
+              onClick={selectToday}
+              className="text-xs text-text-muted hover:text-text-primary"
+            >
+              Heute
+            </button>
+            <button
+              type="button"
+              onClick={() => setOpen(false)}
+              className="text-xs text-text-muted hover:text-text-primary"
+            >
+              Schließen
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/Lightbox.tsx
+++ b/frontend/src/components/Lightbox.tsx
@@ -1,0 +1,117 @@
+import { useEffect, useCallback } from 'react';
+
+interface LightboxProps {
+  images: { url: string; caption?: string | null }[];
+  index: number;
+  onClose: () => void;
+  onNavigate: (newIndex: number) => void;
+}
+
+export function Lightbox({ images, index, onClose, onNavigate }: LightboxProps) {
+  const total = images.length;
+
+  const goPrev = useCallback(() => {
+    onNavigate((index - 1 + total) % total);
+  }, [index, total, onNavigate]);
+
+  const goNext = useCallback(() => {
+    onNavigate((index + 1) % total);
+  }, [index, total, onNavigate]);
+
+  // Keyboard handling
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') onClose();
+      else if (e.key === 'ArrowLeft') goPrev();
+      else if (e.key === 'ArrowRight') goNext();
+    }
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onClose, goPrev, goNext]);
+
+  // Body-Scroll sperren während Lightbox offen
+  useEffect(() => {
+    const original = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = original;
+    };
+  }, []);
+
+  if (total === 0) return null;
+  const current = images[index];
+
+  return (
+    <div
+      className="fixed inset-0 z-[100] bg-black/90 flex items-center justify-center"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+    >
+      {/* Close-Button */}
+      <button
+        type="button"
+        onClick={(e) => { e.stopPropagation(); onClose(); }}
+        className="absolute top-4 right-4 text-white/80 hover:text-white p-2"
+        aria-label="Schließen"
+      >
+        <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <line x1="18" y1="6" x2="6" y2="18" />
+          <line x1="6" y1="6" x2="18" y2="18" />
+        </svg>
+      </button>
+
+      {/* Counter */}
+      {total > 1 && (
+        <div className="absolute top-4 left-4 text-white/70 text-sm tabular-nums">
+          {index + 1} / {total}
+        </div>
+      )}
+
+      {/* Prev */}
+      {total > 1 && (
+        <button
+          type="button"
+          onClick={(e) => { e.stopPropagation(); goPrev(); }}
+          className="absolute left-2 sm:left-4 text-white/80 hover:text-white p-2"
+          aria-label="Vorheriges Bild"
+        >
+          <svg width="36" height="36" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <polyline points="15 18 9 12 15 6" />
+          </svg>
+        </button>
+      )}
+
+      {/* Next */}
+      {total > 1 && (
+        <button
+          type="button"
+          onClick={(e) => { e.stopPropagation(); goNext(); }}
+          className="absolute right-2 sm:right-4 text-white/80 hover:text-white p-2"
+          aria-label="Nächstes Bild"
+        >
+          <svg width="36" height="36" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <polyline points="9 18 15 12 9 6" />
+          </svg>
+        </button>
+      )}
+
+      {/* Image + Caption */}
+      <div
+        className="max-w-[90vw] max-h-[90vh] flex flex-col items-center"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <img
+          src={current.url}
+          alt={current.caption || ''}
+          className="max-w-full max-h-[80vh] object-contain"
+        />
+        {current.caption && (
+          <p className="text-white/80 text-sm mt-3 text-center max-w-2xl px-4">
+            {current.caption}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -37,6 +37,9 @@ export function Navbar() {
               {user.is_member && (
                 <Link to="/saisonkalender" className={linkClass}>Saisonkalender</Link>
               )}
+              {user.is_admin && (
+                <Link to="/diary" className={linkClass}>Tagebuch</Link>
+              )}
               {user.is_household && (
                 <Link to="/einkaufsliste" className={linkClass}>Einkaufsliste</Link>
               )}
@@ -107,6 +110,9 @@ export function Navbar() {
                 )}
                 {user.is_member && (
                   <Link to="/saisonkalender" className={mobileLinkClass}>Saisonkalender</Link>
+                )}
+                {user.is_admin && (
+                  <Link to="/diary" className={mobileLinkClass}>Tagebuch</Link>
                 )}
                 {user.is_household && (
                   <Link to="/einkaufsliste" className={mobileLinkClass}>Einkaufsliste</Link>

--- a/frontend/src/pages/Diary.tsx
+++ b/frontend/src/pages/Diary.tsx
@@ -1,0 +1,330 @@
+import { useState, useEffect, useMemo } from 'react';
+import { Link, Navigate } from 'react-router-dom';
+import { Layout } from '../components/Layout';
+import { NotFound } from './NotFound';
+import { Lightbox } from '../components/Lightbox';
+import { useAuth } from '../hooks/useAuth';
+import { listEntries, imageUrl } from '../api/diary';
+import type { DiaryEntry, DiaryImage } from '../types';
+
+type ViewMode = 'list' | 'calendar';
+
+const MONTHS_DE = [
+  'Januar', 'Februar', 'März', 'April', 'Mai', 'Juni',
+  'Juli', 'August', 'September', 'Oktober', 'November', 'Dezember',
+];
+const WEEKDAYS_DE = ['Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa', 'So'];
+
+function pad(n: number): string {
+  return n.toString().padStart(2, '0');
+}
+
+function formatDateLong(iso: string): string {
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(iso);
+  if (!m) return iso;
+  const d = new Date(Number(m[1]), Number(m[2]) - 1, Number(m[3]));
+  const weekday = ['Sonntag', 'Montag', 'Dienstag', 'Mittwoch', 'Donnerstag', 'Freitag', 'Samstag'][d.getDay()];
+  return `${weekday}, ${d.getDate()}. ${MONTHS_DE[d.getMonth()]} ${d.getFullYear()}`;
+}
+
+function formatTime(iso: string): string {
+  // "HH:MM:SS" → "HH:MM"
+  return iso.slice(0, 5);
+}
+
+export function Diary() {
+  const { user, loading: authLoading } = useAuth();
+  const [entries, setEntries] = useState<DiaryEntry[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [view, setView] = useState<ViewMode>('list');
+  const [lightboxImages, setLightboxImages] = useState<DiaryImage[] | null>(null);
+  const [lightboxIndex, setLightboxIndex] = useState(0);
+
+  // Kalender-Navigation
+  const today = new Date();
+  const [calYear, setCalYear] = useState(today.getFullYear());
+  const [calMonth, setCalMonth] = useState(today.getMonth());
+
+  useEffect(() => {
+    if (authLoading || !user?.is_admin) return;
+    listEntries()
+      .then(setEntries)
+      .catch(e => setError(e.message || 'Fehler beim Laden'));
+  }, [authLoading, user?.is_admin]);
+
+  // Map: "YYYY-MM-DD" → DiaryEntry[] (für Kalender-Lookup)
+  const entriesByDate = useMemo(() => {
+    const map = new Map<string, DiaryEntry[]>();
+    if (!entries) return map;
+    for (const e of entries) {
+      const list = map.get(e.entry_date) ?? [];
+      list.push(e);
+      map.set(e.entry_date, list);
+    }
+    return map;
+  }, [entries]);
+
+  if (authLoading) {
+    return (
+      <Layout>
+        <div className="max-w-5xl mx-auto px-4 sm:px-8 py-8">
+          <p className="text-text-muted text-sm">Lade...</p>
+        </div>
+      </Layout>
+    );
+  }
+
+  if (!user) {
+    return <Navigate to="/login" replace />;
+  }
+  if (!user.is_admin) {
+    return <NotFound />;
+  }
+
+  function openLightbox(images: DiaryImage[], index: number) {
+    setLightboxImages(images);
+    setLightboxIndex(index);
+  }
+
+  function prevCalMonth() {
+    if (calMonth === 0) { setCalMonth(11); setCalYear(calYear - 1); }
+    else setCalMonth(calMonth - 1);
+  }
+  function nextCalMonth() {
+    if (calMonth === 11) { setCalMonth(0); setCalYear(calYear + 1); }
+    else setCalMonth(calMonth + 1);
+  }
+
+  // Kalender-Cells
+  const firstOfMonth = new Date(calYear, calMonth, 1);
+  const firstWeekday = (firstOfMonth.getDay() + 6) % 7;
+  const daysInMonth = new Date(calYear, calMonth + 1, 0).getDate();
+  const calCells: (number | null)[] = [];
+  for (let i = 0; i < firstWeekday; i++) calCells.push(null);
+  for (let d = 1; d <= daysInMonth; d++) calCells.push(d);
+  while (calCells.length % 7 !== 0) calCells.push(null);
+
+  return (
+    <Layout>
+      <div className="max-w-5xl mx-auto px-4 sm:px-8 py-8">
+        <div className="flex flex-wrap items-center justify-between gap-3 mb-6">
+          <h1 className="text-2xl font-medium text-text-primary">Fototagebuch</h1>
+          <div className="flex items-center gap-2">
+            <div className="flex border border-border rounded-lg overflow-hidden">
+              <button
+                type="button"
+                onClick={() => setView('list')}
+                className={`px-3 py-1.5 text-sm transition-colors ${
+                  view === 'list'
+                    ? 'bg-text-primary text-bg-primary'
+                    : 'text-text-muted hover:text-text-primary'
+                }`}
+              >
+                Liste
+              </button>
+              <button
+                type="button"
+                onClick={() => setView('calendar')}
+                className={`px-3 py-1.5 text-sm transition-colors ${
+                  view === 'calendar'
+                    ? 'bg-text-primary text-bg-primary'
+                    : 'text-text-muted hover:text-text-primary'
+                }`}
+              >
+                Kalender
+              </button>
+            </div>
+            <Link
+              to="/diary/neu"
+              className="px-3 py-1.5 text-sm rounded-lg bg-text-primary text-bg-primary hover:opacity-90 transition-opacity"
+            >
+              + Neuer Eintrag
+            </Link>
+          </div>
+        </div>
+
+        {error && (
+          <div className="mb-4 p-3 bg-red-50 text-red-800 border border-red-200 rounded-lg text-sm">
+            {error}
+          </div>
+        )}
+
+        {!entries && !error && (
+          <p className="text-text-muted text-sm">Lade Einträge...</p>
+        )}
+
+        {entries && entries.length === 0 && (
+          <div className="text-center py-12">
+            <p className="text-text-muted">Noch keine Einträge.</p>
+            <Link
+              to="/diary/neu"
+              className="inline-block mt-4 text-sm text-text-primary underline hover:opacity-70"
+            >
+              Ersten Eintrag anlegen
+            </Link>
+          </div>
+        )}
+
+        {/* ---------- Liste ---------- */}
+        {entries && entries.length > 0 && view === 'list' && (
+          <div className="space-y-8">
+            {entries.map(entry => (
+              <article
+                key={entry.id}
+                className="border border-border rounded-lg p-4 sm:p-6 bg-bg-secondary"
+              >
+                <div className="flex flex-wrap items-start justify-between gap-2 mb-3">
+                  <div>
+                    <h2 className="text-base font-medium text-text-primary">
+                      {formatDateLong(entry.entry_date)}
+                    </h2>
+                    <p className="text-xs text-text-muted">{formatTime(entry.entry_time)}</p>
+                  </div>
+                  <Link
+                    to={`/diary/${entry.id}/bearbeiten`}
+                    className="text-xs text-text-muted hover:text-text-primary underline"
+                  >
+                    Bearbeiten
+                  </Link>
+                </div>
+
+                {entry.description && (
+                  <p className="text-sm text-text-primary whitespace-pre-wrap mb-4">
+                    {entry.description}
+                  </p>
+                )}
+
+                {entry.images.length > 0 && (
+                  <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-2">
+                    {entry.images.map((img, idx) => (
+                      <button
+                        type="button"
+                        key={img.id}
+                        onClick={() => openLightbox(entry.images, idx)}
+                        className="block aspect-square overflow-hidden rounded-lg bg-bg-primary group"
+                      >
+                        <img
+                          src={imageUrl(img.thumb_url)}
+                          alt={img.caption || ''}
+                          loading="lazy"
+                          className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
+                        />
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </article>
+            ))}
+          </div>
+        )}
+
+        {/* ---------- Kalender ---------- */}
+        {entries && view === 'calendar' && (
+          <div className="border border-border rounded-lg p-4 bg-bg-secondary">
+            <div className="flex items-center justify-between mb-4">
+              <button
+                type="button"
+                onClick={prevCalMonth}
+                className="p-2 text-text-muted hover:text-text-primary"
+                aria-label="Vorheriger Monat"
+              >
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <polyline points="15 18 9 12 15 6" />
+                </svg>
+              </button>
+              <h2 className="text-base font-medium text-text-primary">
+                {MONTHS_DE[calMonth]} {calYear}
+              </h2>
+              <button
+                type="button"
+                onClick={nextCalMonth}
+                className="p-2 text-text-muted hover:text-text-primary"
+                aria-label="Nächster Monat"
+              >
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <polyline points="9 18 15 12 9 6" />
+                </svg>
+              </button>
+            </div>
+
+            <div className="grid grid-cols-7 gap-1 mb-1">
+              {WEEKDAYS_DE.map(w => (
+                <div key={w} className="text-center text-xs text-text-muted py-1">{w}</div>
+              ))}
+            </div>
+
+            <div className="grid grid-cols-7 gap-1">
+              {calCells.map((day, i) => {
+                if (day === null) return <div key={i} className="aspect-square" />;
+                const iso = `${calYear}-${pad(calMonth + 1)}-${pad(day)}`;
+                const dayEntries = entriesByDate.get(iso) ?? [];
+                const firstImg = dayEntries.find(e => e.images.length > 0)?.images[0];
+                const isToday = iso === `${today.getFullYear()}-${pad(today.getMonth() + 1)}-${pad(today.getDate())}`;
+                const totalImages = dayEntries.reduce((sum, e) => sum + e.images.length, 0);
+
+                if (dayEntries.length === 0) {
+                  return (
+                    <div
+                      key={i}
+                      className={`aspect-square rounded text-xs flex items-start justify-end p-1 text-text-muted ${
+                        isToday ? 'border border-text-muted' : ''
+                      }`}
+                    >
+                      {day}
+                    </div>
+                  );
+                }
+
+                return (
+                  <button
+                    type="button"
+                    key={i}
+                    onClick={() => {
+                      // Erste Bild öffnen falls vorhanden
+                      const allImages = dayEntries.flatMap(e => e.images);
+                      if (allImages.length > 0) openLightbox(allImages, 0);
+                    }}
+                    className="relative aspect-square rounded overflow-hidden bg-bg-primary group"
+                    aria-label={`${day}. ${MONTHS_DE[calMonth]}: ${dayEntries.length} Einträge`}
+                  >
+                    {firstImg ? (
+                      <img
+                        src={imageUrl(firstImg.thumb_url)}
+                        alt=""
+                        loading="lazy"
+                        className="absolute inset-0 w-full h-full object-cover group-hover:scale-105 transition-transform"
+                      />
+                    ) : (
+                      <div className="absolute inset-0 bg-bg-primary" />
+                    )}
+                    <div className="absolute inset-0 bg-gradient-to-t from-black/60 to-transparent" />
+                    <span className="absolute top-1 right-1 text-xs text-white font-medium drop-shadow">
+                      {day}
+                    </span>
+                    {totalImages > 1 && (
+                      <span className="absolute bottom-1 right-1 text-[10px] text-white bg-black/50 rounded px-1 tabular-nums">
+                        {totalImages}
+                      </span>
+                    )}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        )}
+      </div>
+
+      {lightboxImages && (
+        <Lightbox
+          images={lightboxImages.map(img => ({
+            url: imageUrl(img.url),
+            caption: img.caption,
+          }))}
+          index={lightboxIndex}
+          onClose={() => setLightboxImages(null)}
+          onNavigate={setLightboxIndex}
+        />
+      )}
+    </Layout>
+  );
+}

--- a/frontend/src/pages/DiaryEdit.tsx
+++ b/frontend/src/pages/DiaryEdit.tsx
@@ -1,0 +1,477 @@
+import { useState, useEffect, useRef } from 'react';
+import { useParams, useNavigate, Navigate, Link } from 'react-router-dom';
+import {
+  DndContext,
+  closestCenter,
+  PointerSensor,
+  KeyboardSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  arrayMove,
+  rectSortingStrategy,
+  sortableKeyboardCoordinates,
+  useSortable,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { Layout } from '../components/Layout';
+import { NotFound } from './NotFound';
+import { Datepicker } from '../components/Datepicker';
+import { Lightbox } from '../components/Lightbox';
+import { useAuth } from '../hooks/useAuth';
+import {
+  getEntry,
+  updateEntry,
+  deleteEntry,
+  uploadImages,
+  updateImage,
+  deleteImage,
+  reorderImages,
+  imageUrl,
+} from '../api/diary';
+import type { DiaryEntry, DiaryImage } from '../types';
+
+// ---------- Sortable Image Card ----------
+
+interface SortableImageProps {
+  image: DiaryImage;
+  onClick: () => void;
+  onCaptionChange: (caption: string) => void;
+  onCaptionSave: () => void;
+  onDelete: () => void;
+  draftCaption: string;
+  isDirty: boolean;
+}
+
+function SortableImage(props: SortableImageProps) {
+  const {
+    image, onClick, onCaptionChange, onCaptionSave, onDelete, draftCaption, isDirty,
+  } = props;
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
+    useSortable({ id: image.id });
+
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className="border border-border rounded-lg bg-bg-secondary overflow-hidden"
+    >
+      <div className="relative aspect-square group">
+        {/* Drag-Handle: oben mittig, sichtbar */}
+        <button
+          type="button"
+          {...attributes}
+          {...listeners}
+          className="absolute top-1 left-1 z-10 p-1.5 bg-black/60 text-white rounded cursor-grab active:cursor-grabbing"
+          aria-label="Verschieben"
+          title="Zum Sortieren ziehen"
+        >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <circle cx="9" cy="6" r="1" /><circle cx="9" cy="12" r="1" /><circle cx="9" cy="18" r="1" />
+            <circle cx="15" cy="6" r="1" /><circle cx="15" cy="12" r="1" /><circle cx="15" cy="18" r="1" />
+          </svg>
+        </button>
+
+        {/* Delete-Button rechts oben */}
+        <button
+          type="button"
+          onClick={onDelete}
+          className="absolute top-1 right-1 z-10 p-1.5 bg-black/60 text-white rounded hover:bg-red-600/80 transition-colors"
+          aria-label="Bild löschen"
+          title="Bild löschen"
+        >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
+          </svg>
+        </button>
+
+        {/* Bild — Klick öffnet Lightbox */}
+        <button
+          type="button"
+          onClick={onClick}
+          className="block w-full h-full"
+        >
+          <img
+            src={imageUrl(image.thumb_url)}
+            alt={image.caption || ''}
+            loading="lazy"
+            className="w-full h-full object-cover"
+          />
+        </button>
+      </div>
+
+      {/* Caption-Editor */}
+      <div className="p-2">
+        <div className="flex gap-1">
+          <input
+            type="text"
+            value={draftCaption}
+            onChange={e => onCaptionChange(e.target.value)}
+            placeholder="Bildunterschrift (optional)"
+            maxLength={500}
+            className="flex-1 min-w-0 px-2 py-1 text-xs border border-border rounded bg-bg-primary text-text-primary focus:outline-none focus:border-text-muted"
+          />
+          {isDirty && (
+            <button
+              type="button"
+              onClick={onCaptionSave}
+              className="px-2 text-xs rounded bg-text-primary text-bg-primary hover:opacity-90"
+              title="Bildunterschrift speichern"
+            >
+              ✓
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---------- Page ----------
+
+export function DiaryEdit() {
+  const { id } = useParams<{ id: string }>();
+  const entryId = Number(id);
+  const navigate = useNavigate();
+  const { user, loading: authLoading } = useAuth();
+
+  const [entry, setEntry] = useState<DiaryEntry | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  // Edit-State für Eintrag
+  const [entryDate, setEntryDate] = useState('');
+  const [description, setDescription] = useState('');
+  const [savingEntry, setSavingEntry] = useState(false);
+  const [entryDirty, setEntryDirty] = useState(false);
+
+  // Caption-Drafts pro Bild-ID
+  const [captionDrafts, setCaptionDrafts] = useState<Record<number, string>>({});
+
+  // Upload-State
+  const [uploading, setUploading] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // Lightbox
+  const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
+
+  useEffect(() => {
+    if (authLoading || !user?.is_admin || !entryId) return;
+    getEntry(entryId)
+      .then(e => {
+        setEntry(e);
+        setEntryDate(e.entry_date);
+        setDescription(e.description || '');
+        const drafts: Record<number, string> = {};
+        for (const img of e.images) drafts[img.id] = img.caption || '';
+        setCaptionDrafts(drafts);
+      })
+      .catch(e => setLoadError(e.message || 'Fehler beim Laden'));
+  }, [authLoading, user?.is_admin, entryId]);
+
+  if (authLoading) {
+    return <Layout><div className="max-w-3xl mx-auto px-4 sm:px-8 py-8"><p className="text-text-muted text-sm">Lade...</p></div></Layout>;
+  }
+  if (!user) return <Navigate to="/login" replace />;
+  if (!user.is_admin) return <NotFound />;
+
+  if (loadError) {
+    return (
+      <Layout>
+        <div className="max-w-3xl mx-auto px-4 sm:px-8 py-8">
+          <p className="text-red-700 text-sm">{loadError}</p>
+          <Link to="/diary" className="text-sm text-text-muted underline mt-4 inline-block">← Zurück zur Übersicht</Link>
+        </div>
+      </Layout>
+    );
+  }
+  if (!entry) {
+    return <Layout><div className="max-w-3xl mx-auto px-4 sm:px-8 py-8"><p className="text-text-muted text-sm">Lade Eintrag...</p></div></Layout>;
+  }
+
+  // ---------- Handlers ----------
+
+  function markEntryDirty<T>(setter: (v: T) => void, value: T) {
+    setter(value);
+    setEntryDirty(true);
+  }
+
+  async function saveEntryMeta() {
+    if (!entry) return;
+    setSavingEntry(true);
+    setActionError(null);
+    try {
+      const updated = await updateEntry(entry.id, {
+        entry_date: entryDate,
+        description: description.trim() || null,
+      });
+      setEntry(updated);
+      setEntryDirty(false);
+    } catch (e: any) {
+      setActionError(e.message || 'Fehler beim Speichern');
+    } finally {
+      setSavingEntry(false);
+    }
+  }
+
+  async function handleDeleteEntry() {
+    if (!entry) return;
+    if (!confirm(`Eintrag vom ${entry.entry_date} wirklich löschen? Alle Bilder werden mit gelöscht.`)) return;
+    try {
+      await deleteEntry(entry.id);
+      navigate('/diary');
+    } catch (e: any) {
+      setActionError(e.message || 'Fehler beim Löschen');
+    }
+  }
+
+  async function handleUpload(e: React.ChangeEvent<HTMLInputElement>) {
+    if (!entry) return;
+    const files = e.target.files ? Array.from(e.target.files) : [];
+    if (files.length === 0) return;
+    setUploading(true);
+    setActionError(null);
+    try {
+      const newImgs = await uploadImages(entry.id, files);
+      // Refetch für konsistenten State (Reihenfolge etc.)
+      const refreshed = await getEntry(entry.id);
+      setEntry(refreshed);
+      const drafts: Record<number, string> = { ...captionDrafts };
+      for (const img of newImgs) drafts[img.id] = '';
+      setCaptionDrafts(drafts);
+    } catch (e: any) {
+      setActionError(e.message || 'Upload fehlgeschlagen');
+    } finally {
+      setUploading(false);
+      if (fileInputRef.current) fileInputRef.current.value = '';
+    }
+  }
+
+  async function handleCaptionSave(imageId: number) {
+    if (!entry) return;
+    setActionError(null);
+    try {
+      const draft = captionDrafts[imageId] ?? '';
+      const updated = await updateImage(imageId, {
+        caption: draft.trim() ? draft : null,
+      });
+      setEntry({
+        ...entry,
+        images: entry.images.map(img => img.id === imageId ? { ...img, caption: updated.caption } : img),
+      });
+    } catch (e: any) {
+      setActionError(e.message || 'Caption-Update fehlgeschlagen');
+    }
+  }
+
+  async function handleDeleteImage(imageId: number) {
+    if (!entry) return;
+    if (!confirm('Bild wirklich löschen?')) return;
+    setActionError(null);
+    try {
+      await deleteImage(imageId);
+      setEntry({
+        ...entry,
+        images: entry.images.filter(img => img.id !== imageId),
+      });
+      const { [imageId]: _, ...rest } = captionDrafts;
+      setCaptionDrafts(rest);
+    } catch (e: any) {
+      setActionError(e.message || 'Löschen fehlgeschlagen');
+    }
+  }
+
+  async function handleDragEnd(event: DragEndEvent) {
+    if (!entry) return;
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+
+    const oldIndex = entry.images.findIndex(img => img.id === active.id);
+    const newIndex = entry.images.findIndex(img => img.id === over.id);
+    if (oldIndex === -1 || newIndex === -1) return;
+
+    // Optimistisches Update
+    const reordered = arrayMove(entry.images, oldIndex, newIndex);
+    setEntry({ ...entry, images: reordered });
+
+    setActionError(null);
+    try {
+      const updated = await reorderImages(entry.id, reordered.map(img => img.id));
+      setEntry({ ...entry, images: updated });
+    } catch (e: any) {
+      setActionError(e.message || 'Reorder fehlgeschlagen');
+      // Refetch für konsistenten State
+      try {
+        const refreshed = await getEntry(entry.id);
+        setEntry(refreshed);
+      } catch { /* ignore */ }
+    }
+  }
+
+  // ---------- Render ----------
+
+  return (
+    <Layout>
+      <div className="max-w-3xl mx-auto px-4 sm:px-8 py-8">
+        <div className="mb-6 flex items-start justify-between gap-3">
+          <div>
+            <Link to="/diary" className="text-xs text-text-muted hover:text-text-primary">
+              ← Zurück zur Übersicht
+            </Link>
+            <h1 className="text-2xl font-medium text-text-primary mt-2">Eintrag bearbeiten</h1>
+          </div>
+          <button
+            type="button"
+            onClick={handleDeleteEntry}
+            className="text-xs text-red-700 hover:text-red-900 underline"
+          >
+            Eintrag löschen
+          </button>
+        </div>
+
+        {actionError && (
+          <div className="mb-4 p-3 bg-red-50 text-red-800 border border-red-200 rounded-lg text-sm">
+            {actionError}
+          </div>
+        )}
+
+        {/* Eintrag-Meta */}
+        <section className="mb-8 space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-text-primary mb-1">Datum</label>
+            <Datepicker value={entryDate} onChange={(v) => markEntryDirty(setEntryDate, v)} />
+          </div>
+
+          <div>
+            <label htmlFor="description" className="block text-sm font-medium text-text-primary mb-1">
+              Beschreibung <span className="text-text-muted font-normal">(optional)</span>
+            </label>
+            <textarea
+              id="description"
+              value={description}
+              onChange={e => markEntryDirty(setDescription, e.target.value)}
+              rows={5}
+              maxLength={10000}
+              className="w-full px-3 py-2 border border-border rounded-lg bg-bg-primary text-text-primary text-sm focus:outline-none focus:border-text-muted resize-y"
+            />
+          </div>
+
+          {entryDirty && (
+            <div className="flex items-center gap-3">
+              <button
+                type="button"
+                onClick={saveEntryMeta}
+                disabled={savingEntry}
+                className="px-4 py-2 rounded-lg bg-text-primary text-bg-primary text-sm hover:opacity-90 transition-opacity disabled:opacity-50"
+              >
+                {savingEntry ? 'Speichern...' : 'Änderungen speichern'}
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  setEntryDate(entry.entry_date);
+                  setDescription(entry.description || '');
+                  setEntryDirty(false);
+                }}
+                className="text-sm text-text-muted hover:text-text-primary"
+              >
+                Verwerfen
+              </button>
+            </div>
+          )}
+        </section>
+
+        {/* Bilder */}
+        <section>
+          <div className="flex items-center justify-between mb-3">
+            <h2 className="text-lg font-medium text-text-primary">
+              Bilder <span className="text-sm text-text-muted font-normal">({entry.images.length})</span>
+            </h2>
+            <label className="cursor-pointer">
+              <input
+                ref={fileInputRef}
+                type="file"
+                multiple
+                accept="image/jpeg,image/png,image/webp"
+                onChange={handleUpload}
+                disabled={uploading}
+                className="hidden"
+              />
+              <span className="inline-block px-3 py-1.5 text-sm rounded-lg bg-text-primary text-bg-primary hover:opacity-90 transition-opacity">
+                {uploading ? 'Lade hoch...' : '+ Bilder hinzufügen'}
+              </span>
+            </label>
+          </div>
+
+          {entry.images.length === 0 ? (
+            <p className="text-text-muted text-sm py-8 text-center border border-dashed border-border rounded-lg">
+              Noch keine Bilder. Lade welche hoch über den Button oben rechts.
+            </p>
+          ) : (
+            <DndContext
+              sensors={sensors}
+              collisionDetection={closestCenter}
+              onDragEnd={handleDragEnd}
+            >
+              <SortableContext
+                items={entry.images.map(img => img.id)}
+                strategy={rectSortingStrategy}
+              >
+                <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+                  {entry.images.map((img, idx) => {
+                    const draft = captionDrafts[img.id] ?? '';
+                    const isDirty = draft.trim() !== (img.caption || '').trim();
+                    return (
+                      <SortableImage
+                        key={img.id}
+                        image={img}
+                        onClick={() => setLightboxIndex(idx)}
+                        onCaptionChange={(v) => setCaptionDrafts({ ...captionDrafts, [img.id]: v })}
+                        onCaptionSave={() => handleCaptionSave(img.id)}
+                        onDelete={() => handleDeleteImage(img.id)}
+                        draftCaption={draft}
+                        isDirty={isDirty}
+                      />
+                    );
+                  })}
+                </div>
+              </SortableContext>
+            </DndContext>
+          )}
+
+          {entry.images.length > 0 && (
+            <p className="mt-3 text-xs text-text-muted">
+              Tipp: Bilder mit dem Griff (oben links) per Drag & Drop sortieren.
+            </p>
+          )}
+        </section>
+      </div>
+
+      {lightboxIndex !== null && entry.images.length > 0 && (
+        <Lightbox
+          images={entry.images.map(img => ({
+            url: imageUrl(img.url),
+            caption: img.caption,
+          }))}
+          index={lightboxIndex}
+          onClose={() => setLightboxIndex(null)}
+          onNavigate={setLightboxIndex}
+        />
+      )}
+    </Layout>
+  );
+}

--- a/frontend/src/pages/DiaryNew.tsx
+++ b/frontend/src/pages/DiaryNew.tsx
@@ -1,0 +1,127 @@
+import { useState } from 'react';
+import { useNavigate, Navigate, Link } from 'react-router-dom';
+import { Layout } from '../components/Layout';
+import { NotFound } from './NotFound';
+import { Datepicker } from '../components/Datepicker';
+import { useAuth } from '../hooks/useAuth';
+import { createEntry } from '../api/diary';
+
+function pad(n: number): string {
+  return n.toString().padStart(2, '0');
+}
+
+function todayISO(): string {
+  const d = new Date();
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+}
+
+export function DiaryNew() {
+  const { user, loading: authLoading } = useAuth();
+  const navigate = useNavigate();
+  const [entryDate, setEntryDate] = useState<string>(todayISO());
+  const [description, setDescription] = useState<string>('');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  if (authLoading) {
+    return (
+      <Layout>
+        <div className="max-w-2xl mx-auto px-4 sm:px-8 py-8">
+          <p className="text-text-muted text-sm">Lade...</p>
+        </div>
+      </Layout>
+    );
+  }
+  if (!user) return <Navigate to="/login" replace />;
+  if (!user.is_admin) return <NotFound />;
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!entryDate) {
+      setError('Bitte ein Datum wählen.');
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    try {
+      const created = await createEntry({
+        entry_date: entryDate,
+        description: description.trim() || null,
+      });
+      // Direkt in die Edit-View springen, damit Bilder hochgeladen werden können
+      navigate(`/diary/${created.id}/bearbeiten`);
+    } catch (e: any) {
+      setError(e.message || 'Fehler beim Speichern');
+      setSaving(false);
+    }
+  }
+
+  return (
+    <Layout>
+      <div className="max-w-2xl mx-auto px-4 sm:px-8 py-8">
+        <div className="mb-6">
+          <Link
+            to="/diary"
+            className="text-xs text-text-muted hover:text-text-primary"
+          >
+            ← Zurück zur Übersicht
+          </Link>
+          <h1 className="text-2xl font-medium text-text-primary mt-2">Neuer Eintrag</h1>
+        </div>
+
+        {error && (
+          <div className="mb-4 p-3 bg-red-50 text-red-800 border border-red-200 rounded-lg text-sm">
+            {error}
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit} className="space-y-5">
+          <div>
+            <label className="block text-sm font-medium text-text-primary mb-1">
+              Datum
+            </label>
+            <Datepicker value={entryDate} onChange={setEntryDate} />
+          </div>
+
+          <div>
+            <label
+              htmlFor="description"
+              className="block text-sm font-medium text-text-primary mb-1"
+            >
+              Beschreibung <span className="text-text-muted font-normal">(optional)</span>
+            </label>
+            <textarea
+              id="description"
+              value={description}
+              onChange={e => setDescription(e.target.value)}
+              rows={5}
+              maxLength={10000}
+              className="w-full px-3 py-2 border border-border rounded-lg bg-bg-primary text-text-primary text-sm focus:outline-none focus:border-text-muted resize-y"
+              placeholder="Was war heute los?"
+            />
+          </div>
+
+          <div className="flex items-center gap-3">
+            <button
+              type="submit"
+              disabled={saving}
+              className="px-4 py-2 rounded-lg bg-text-primary text-bg-primary text-sm hover:opacity-90 transition-opacity disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {saving ? 'Speichern...' : 'Anlegen & Bilder hochladen'}
+            </button>
+            <Link
+              to="/diary"
+              className="text-sm text-text-muted hover:text-text-primary"
+            >
+              Abbrechen
+            </Link>
+          </div>
+
+          <p className="text-xs text-text-muted">
+            Nach dem Anlegen kommst du zur Bearbeitungsansicht, wo du Bilder hinzufügen kannst.
+          </p>
+        </form>
+      </div>
+    </Layout>
+  );
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -174,3 +174,26 @@ export interface RecipeComment {
   created_at: string;
   updated_at: string;
 }
+
+// ---------- Foto-Tagebuch ----------
+export interface DiaryImage {
+  id: number;
+  url: string;        // relativer Pfad, z.B. "/uploads/diary/<uuid>.webp"
+  thumb_url: string;  // relativer Pfad, z.B. "/uploads/diary/thumbs/<uuid>.webp"
+  caption: string | null;
+  position: number;
+}
+
+export interface DiaryEntry {
+  id: number;
+  entry_date: string;   // ISO date "YYYY-MM-DD"
+  entry_time: string;   // ISO time "HH:MM:SS"
+  description: string | null;
+  images: DiaryImage[];
+}
+
+export interface DiaryEntryInput {
+  entry_date: string;
+  entry_time?: string;
+  description?: string | null;
+}


### PR DESCRIPTION
## Was

Neues Feature: Fototagebuch für Admins. Mehrere Einträge pro Tag mit Datum,
Zeit, optionaler Beschreibung und beliebig vielen Bildern.

## Sichtbarkeit

- Public route \`/diary\` — aber komplett hinter Admin-Auth.
- Nicht-Admins (auch ohne Login) bekommen 404, kein Hint dass die Route existiert.
- Navi-Eintrag \"Tagebuch\" nur für Admins sichtbar.

## Backend

- Neue Tabellen \`photo_diary_entries\` + \`photo_diary_images\` (1:n CASCADE).
- Migration auf frischer DB getestet (Wegwerf-Postgres + alembic upgrade head).
- Bilder bei Upload → WebP, max. 2000px Vollbild + 600px Thumb. Eigene
  Funktion \`save_diary_image()\`, das bestehende \`save_image()\` bleibt
  unverändert (Recipes/Avatar nutzen es weiter).
- Router komplett admin-only, alle Endpoints mit \`Depends(require_admin)\`.
- 30 pytest-Tests grün, 1 skip für SQLite-CASCADE (gegen Postgres via
  \`docker-compose.test.yml\` verifiziert).

## Frontend

- Drei Pages: \`/diary\` (Übersicht), \`/diary/neu\` (anlegen),
  \`/diary/:id/bearbeiten\` (bearbeiten + Bild-Upload + Reorder).
- Übersicht hat Toggle Liste/Kalender. Kalender zeigt Tage mit Einträgen
  als Thumbnail-Tiles mit Counter.
- Drei wiederverwendbare Components: Datepicker (Tailwind-only, deutsch,
  Wochenstart Mo), Lightbox (Overlay mit Pfeiltasten/ESC), SortableImage
  in DiaryEdit (\`@dnd-kit/sortable\`).
- Caption-Editor pro Bild, Save-Button erscheint nur wenn dirty.

## Neue Dependencies

- \`@dnd-kit/core\`, \`@dnd-kit/sortable\`, \`@dnd-kit/utilities\`.

## Stolperfalle die mitkam

Beim \`alembic revision --autogenerate\` hat Alembic einen redundanten
UNIQUE-Index auf \`impostor_categories.name\` als Drift mitgeneriert.
Wurde aus der Migration entfernt — der Drift ist ein separates Thema
und gehört nicht in \`add_photo_diary_tables\`.

## Deploy

Nach Merge: \`./scripts/backup-db.sh && git pull && docker compose build &&
docker compose up -d\` auf dem Pi. Backup ist Pflicht weil Migration
mitläuft.