### PR TITLE
feat(seasonal): remove 'import' availability type

### DIFF
--- a/backend/alembic/versions/35a7d963d996_remove_import_from_seasonal_availability.py
+++ b/backend/alembic/versions/35a7d963d996_remove_import_from_seasonal_availability.py
@@ -1,0 +1,63 @@
+"""remove_import_from_seasonal_availability
+
+Entfernt den Wert "import" aus dem Postgres-Enum seasonal_availability.
+
+Vorgehen:
+1. Alle SeasonalAvailabilityEntry-Rows mit type='import' loeschen.
+2. Neuen Enum-Type seasonal_availability_new mit nur (regional, storage) anlegen.
+3. Spalte seasonal_availabilities.type auf neuen Type casten.
+4. Alten Type droppen, neuen Type umbenennen.
+
+Hinweis: Die geloeschten Rows koennen beim Downgrade NICHT wiederhergestellt
+werden. Ein Downgrade fuegt nur den Enum-Wert "import" wieder hinzu, die Daten
+selbst sind weg.
+
+Revision ID: 35a7d963d996
+Revises: 981139483fef
+Create Date: 2026-05-03
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "35a7d963d996"
+down_revision: Union[str, None] = "981139483fef"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # 1) Daten mit Wert "import" entfernen.
+    op.execute("DELETE FROM seasonal_availabilities WHERE type = 'import'")
+
+    # 2) Neuen Enum-Type ohne "import" anlegen.
+    op.execute("CREATE TYPE seasonal_availability_new AS ENUM ('regional', 'storage')")
+
+    # 3) Spalte auf neuen Type casten (Text-Roundtrip).
+    op.execute(
+        "ALTER TABLE seasonal_availabilities "
+        "ALTER COLUMN type TYPE seasonal_availability_new "
+        "USING type::text::seasonal_availability_new"
+    )
+
+    # 4) Alten Type droppen, neuen umbenennen.
+    op.execute("DROP TYPE seasonal_availability")
+    op.execute("ALTER TYPE seasonal_availability_new RENAME TO seasonal_availability")
+
+
+def downgrade() -> None:
+    # Enum wieder um "import" erweitern. Geloeschte Rows sind unwiederbringlich.
+    op.execute(
+        "CREATE TYPE seasonal_availability_old "
+        "AS ENUM ('regional', 'storage', 'import')"
+    )
+    op.execute(
+        "ALTER TABLE seasonal_availabilities "
+        "ALTER COLUMN type TYPE seasonal_availability_old "
+        "USING type::text::seasonal_availability_old"
+    )
+    op.execute("DROP TYPE seasonal_availability")
+    op.execute("ALTER TYPE seasonal_availability_old RENAME TO seasonal_availability")

--- a/backend/models.py
+++ b/backend/models.py
@@ -153,7 +153,6 @@ class SeasonalCategory(str, _enum_seasonal.Enum):
 class SeasonalAvailability(str, _enum_seasonal.Enum):
     regional = "regional"
     storage = "storage"
-    import_ = "import"
 
 
 class SeasonalItem(Base):

--- a/backend/routers/seasonal.py
+++ b/backend/routers/seasonal.py
@@ -39,7 +39,6 @@ class MonthAvailability(BaseModel):
         order = {
             models.SeasonalAvailability.regional: 0,
             models.SeasonalAvailability.storage: 1,
-            models.SeasonalAvailability.import_: 2,
         }
         return sorted(set(v), key=lambda t: order[t])
 
@@ -139,7 +138,6 @@ def _avail_sort_key(t: models.SeasonalAvailability) -> int:
     order = {
         models.SeasonalAvailability.regional: 0,
         models.SeasonalAvailability.storage: 1,
-        models.SeasonalAvailability.import_: 2,
     }
     return order[t]
 

--- a/backend/scripts/refine_seasonal_data.py
+++ b/backend/scripts/refine_seasonal_data.py
@@ -4,18 +4,16 @@ Seasonal Calendar: korrekte Verfügbarkeitsdaten für Österreich/Mitteleuropa.
 Ersetzt die Verfügbarkeiten der bestehenden seasonal_items mit handgepflegten
 Werten basierend auf österreichischen Saisonkalendern (AMA, Land schafft Leben).
 
-Format pro Item: {month_int: [type, ...]} mit type ∈ {"regional", "storage", "import"}
+Format pro Item: {month_int: [type, ...]} mit type ∈ {"regional", "storage"}
 - "regional" = heimisch frisch geerntet/verfügbar
 - "storage" = heimisch aus Lagerung
-- "import" = überwiegend Import aus dem Ausland
+- Monate ohne Eintrag = nicht verfügbar (z.B. weil nur Importware)
 
 Heuristik:
 - Frische Saison: nur regional
-- Lagerware-Klassiker: regional in Erntezeit + storage über Winter, ggf. import
-  im Übergang (z.B. Kartoffel-Frühkartoffel-Import)
-- Frischgemüse (Tomate, Paprika, Zucchini etc.): regional in Saison, sonst import
-- Beeren/Steinobst: regional in Saison, import in den Hauptmonaten der typischen
-  Importware (Erdbeere/Himbeere häufig importiert)
+- Lagerware-Klassiker: regional in Erntezeit + storage über Winter
+- Frischgemüse (Tomate, Paprika, Zucchini etc.): nur regional in Saison
+- Beeren/Steinobst: nur regional in Saison
 
 Aufruf (im Backend-Container):
   python scripts/refine_seasonal_data.py [--dry-run]
@@ -40,7 +38,6 @@ import models  # noqa: E402
 # Type-Aliases für Lesbarkeit
 R = "regional"
 L = "storage"
-I = "import"
 
 # ---------- Datendefinition ----------
 # Pro Item: dict[Monat 1..12] -> Liste von Verfügbarkeitstypen
@@ -50,221 +47,196 @@ I = "import"
 ITEMS: dict[str, dict[int, list[str]]] = {
     # ===== OBST =====
     "Apfel": {
-        1: [L, I], 2: [L, I], 3: [L, I], 4: [L, I], 5: [I], 6: [I], 7: [I],
-        8: [R], 9: [R], 10: [R, L], 11: [L], 12: [L],
+        1: [L], 2: [L], 3: [L], 4: [L], 8: [R], 9: [R], 10: [R, L], 11: [L], 12: [L]
     },
     "Birne": {
-        1: [L, I], 2: [L, I], 3: [I], 4: [I], 5: [I], 6: [I], 7: [I],
-        8: [R], 9: [R], 10: [R, L], 11: [L], 12: [L, I],
+        1: [L], 2: [L], 8: [R], 9: [R], 10: [R, L], 11: [L], 12: [L]
     },
     "Erdbeere": {
-        1: [I], 2: [I], 3: [I], 4: [I], 5: [R], 6: [R], 7: [R],
-        8: [I], 9: [I], 10: [I], 11: [I], 12: [I],
+        5: [R], 6: [R], 7: [R]
     },
     "Himbeere": {
-        1: [I], 2: [I], 3: [I], 4: [I], 5: [I],
-        6: [R], 7: [R], 8: [R], 9: [R],
-        10: [I], 11: [I], 12: [I],
+        6: [R], 7: [R], 8: [R], 9: [R]
     },
     "Brombeere": {
-        7: [R], 8: [R], 9: [R],
+        7: [R], 8: [R], 9: [R]
     },
     "Heidelbeere": {
-        1: [I], 2: [I], 3: [I], 4: [I], 5: [I], 6: [I],
-        7: [R, I], 8: [R, I], 9: [R, I],
-        10: [I], 11: [I], 12: [I],
+        7: [R], 8: [R], 9: [R]
     },
     "Johannisbeere": {
-        6: [R], 7: [R], 8: [R],
+        6: [R], 7: [R], 8: [R]
     },
     "Stachelbeere": {
-        6: [R], 7: [R], 8: [R],
+        6: [R], 7: [R], 8: [R]
     },
     "Kirsche": {
-        6: [R], 7: [R], 8: [R],
+        6: [R], 7: [R], 8: [R]
     },
     "Marille": {
-        6: [R], 7: [R], 8: [R],
+        6: [R], 7: [R], 8: [R]
     },
     "Pfirsich": {
-        7: [R], 8: [R], 9: [R],
+        7: [R], 8: [R], 9: [R]
     },
     "Nektarine": {
-        7: [R], 8: [R], 9: [R],
+        7: [R], 8: [R], 9: [R]
     },
     "Pflaume": {
-        7: [R], 8: [R], 9: [R], 10: [R],
+        7: [R], 8: [R], 9: [R], 10: [R]
     },
     "Zwetschge": {
-        8: [R], 9: [R], 10: [R],
+        8: [R], 9: [R], 10: [R]
     },
     "Weintraube": {
-        8: [R], 9: [R], 10: [R], 11: [R],
+        8: [R], 9: [R], 10: [R], 11: [R]
     },
     "Rhabarber": {
-        4: [R], 5: [R], 6: [R],
+        4: [R], 5: [R], 6: [R]
     },
     "Quitte": {
-        9: [R], 10: [R], 11: [R],
+        9: [R], 10: [R], 11: [R]
     },
     "Holunderbeere": {
-        8: [R], 9: [R],
+        8: [R], 9: [R]
     },
 
     # ===== GEMÜSE =====
     "Kartoffel": {
-        1: [L], 2: [L], 3: [L], 4: [L, I], 5: [L, I],
+        1: [L], 2: [L], 3: [L], 4: [L], 5: [L],
         6: [R, L], 7: [R], 8: [R], 9: [R], 10: [R, L],
-        11: [L], 12: [L],
+        11: [L], 12: [L]
     },
     "Karotte": {
-        1: [L], 2: [L], 3: [L], 4: [L, I], 5: [I],
-        6: [R], 7: [R], 8: [R], 9: [R, L], 10: [R, L],
-        11: [L], 12: [L],
+        1: [L], 2: [L], 3: [L], 4: [L], 6: [R], 7: [R], 8: [R], 9: [R, L], 10: [R, L],
+        11: [L], 12: [L]
     },
     "Zwiebel": {
-        1: [L], 2: [L], 3: [L], 4: [L], 5: [L, I],
-        6: [I], 7: [R, I], 8: [R], 9: [R, L], 10: [R, L],
-        11: [L], 12: [L],
+        1: [L], 2: [L], 3: [L], 4: [L], 5: [L],
+        7: [R], 8: [R], 9: [R, L], 10: [R, L],
+        11: [L], 12: [L]
     },
     "Knoblauch": {
-        1: [L, I], 2: [L, I], 3: [I], 4: [I], 5: [I], 6: [I],
-        7: [R], 8: [R, L], 9: [L], 10: [L], 11: [L], 12: [L],
+        1: [L], 2: [L], 7: [R], 8: [R, L], 9: [L], 10: [L], 11: [L], 12: [L]
     },
     "Lauch": {
         1: [R], 2: [R], 3: [R], 4: [R],
-        9: [R], 10: [R], 11: [R], 12: [R],
+        9: [R], 10: [R], 11: [R], 12: [R]
     },
     "Rote Rübe": {
         1: [L], 2: [L], 3: [L],
         6: [R], 7: [R], 8: [R], 9: [R, L], 10: [R, L],
-        11: [L], 12: [L],
+        11: [L], 12: [L]
     },
     "Sellerie": {
         1: [L], 2: [L], 3: [L],
-        8: [R], 9: [R, L], 10: [R, L], 11: [L], 12: [L],
+        8: [R], 9: [R, L], 10: [R, L], 11: [L], 12: [L]
     },
     "Pastinake": {
         1: [L], 2: [L], 3: [L],
-        10: [R, L], 11: [L], 12: [L],
+        10: [R, L], 11: [L], 12: [L]
     },
     "Kürbis": {
         1: [L],
-        8: [R], 9: [R], 10: [R, L], 11: [L], 12: [L],
+        8: [R], 9: [R], 10: [R, L], 11: [L], 12: [L]
     },
     "Spinat": {
         3: [R], 4: [R], 5: [R],
-        9: [R], 10: [R], 11: [R],
+        9: [R], 10: [R], 11: [R]
     },
     "Mangold": {
-        5: [R], 6: [R], 7: [R], 8: [R], 9: [R], 10: [R],
+        5: [R], 6: [R], 7: [R], 8: [R], 9: [R], 10: [R]
     },
     "Salat": {
-        1: [I], 2: [I], 3: [I],
-        4: [R], 5: [R], 6: [R], 7: [R], 8: [R], 9: [R], 10: [R],
-        11: [I], 12: [I],
+        4: [R], 5: [R], 6: [R], 7: [R], 8: [R], 9: [R], 10: [R]
     },
     "Vogerlsalat": {
         1: [R], 2: [R], 3: [R],
-        10: [R], 11: [R], 12: [R],
+        10: [R], 11: [R], 12: [R]
     },
     "Chicorée": {
         1: [R], 2: [R], 3: [R], 4: [R],
-        10: [R], 11: [R], 12: [R],
+        10: [R], 11: [R], 12: [R]
     },
     "Radicchio": {
-        6: [R], 7: [R], 8: [R], 9: [R], 10: [R], 11: [R], 12: [R],
+        6: [R], 7: [R], 8: [R], 9: [R], 10: [R], 11: [R], 12: [R]
     },
     "Rucola": {
-        4: [R], 5: [R], 6: [R], 7: [R], 8: [R], 9: [R], 10: [R],
+        4: [R], 5: [R], 6: [R], 7: [R], 8: [R], 9: [R], 10: [R]
     },
     "Tomate": {
-        1: [I], 2: [I], 3: [I], 4: [I], 5: [I],
-        6: [R], 7: [R], 8: [R], 9: [R], 10: [R],
-        11: [I], 12: [I],
+        6: [R], 7: [R], 8: [R], 9: [R], 10: [R]
     },
     "Gurke": {
-        1: [I], 2: [I], 3: [I], 4: [I], 5: [I],
-        6: [R], 7: [R], 8: [R], 9: [R], 10: [R],
-        11: [I], 12: [I],
+        6: [R], 7: [R], 8: [R], 9: [R], 10: [R]
     },
     "Paprika": {
-        1: [I], 2: [I], 3: [I], 4: [I], 5: [I], 6: [I],
-        7: [R], 8: [R], 9: [R], 10: [R],
-        11: [I], 12: [I],
+        7: [R], 8: [R], 9: [R], 10: [R]
     },
     "Zucchini": {
-        1: [I], 2: [I], 3: [I], 4: [I], 5: [I],
-        6: [R], 7: [R], 8: [R], 9: [R], 10: [R],
-        11: [I], 12: [I],
+        6: [R], 7: [R], 8: [R], 9: [R], 10: [R]
     },
     "Aubergine": {
-        1: [I], 2: [I], 3: [I], 4: [I], 5: [I], 6: [I],
-        7: [R], 8: [R], 9: [R], 10: [R],
-        11: [I], 12: [I],
+        7: [R], 8: [R], 9: [R], 10: [R]
     },
     "Brokkoli": {
-        1: [I], 2: [I], 3: [I], 4: [I], 5: [I],
-        6: [R], 7: [R], 8: [R], 9: [R], 10: [R],
-        11: [I], 12: [I],
+        6: [R], 7: [R], 8: [R], 9: [R], 10: [R]
     },
     "Karfiol": {
-        1: [I], 2: [I], 3: [I], 4: [I], 5: [I],
-        6: [R], 7: [R], 8: [R], 9: [R], 10: [R], 11: [R],
-        12: [I],
+        6: [R], 7: [R], 8: [R], 9: [R], 10: [R], 11: [R]
     },
     "Kohlrabi": {
-        5: [R], 6: [R], 7: [R], 8: [R], 9: [R], 10: [R],
+        5: [R], 6: [R], 7: [R], 8: [R], 9: [R], 10: [R]
     },
     "Weißkraut": {
         1: [L], 2: [L], 3: [L],
         6: [R], 7: [R], 8: [R], 9: [R, L], 10: [R, L],
-        11: [L], 12: [L],
+        11: [L], 12: [L]
     },
     "Rotkraut": {
         1: [L], 2: [L], 3: [L],
-        9: [R], 10: [R, L], 11: [L], 12: [L],
+        9: [R], 10: [R, L], 11: [L], 12: [L]
     },
     "Wirsing": {
         1: [L], 2: [L], 3: [L],
         6: [R], 7: [R], 8: [R], 9: [R, L], 10: [R, L],
-        11: [L], 12: [L],
+        11: [L], 12: [L]
     },
     "Grünkohl": {
-        11: [R], 12: [R], 1: [R], 2: [R],
+        11: [R], 12: [R], 1: [R], 2: [R]
     },
     "Kohlsprossen": {
-        10: [R], 11: [R], 12: [R], 1: [R], 2: [R], 3: [R],
+        10: [R], 11: [R], 12: [R], 1: [R], 2: [R], 3: [R]
     },
     "Erbse": {
-        6: [R], 7: [R], 8: [R],
+        6: [R], 7: [R], 8: [R]
     },
     "Bohne": {
-        6: [R], 7: [R], 8: [R], 9: [R], 10: [R],
+        6: [R], 7: [R], 8: [R], 9: [R], 10: [R]
     },
     "Spargel": {
-        4: [R], 5: [R], 6: [R],
+        4: [R], 5: [R], 6: [R]
     },
     "Radieschen": {
-        4: [R], 5: [R], 6: [R], 7: [R], 8: [R], 9: [R], 10: [R],
+        4: [R], 5: [R], 6: [R], 7: [R], 8: [R], 9: [R], 10: [R]
     },
     "Rettich": {
-        5: [R], 6: [R], 7: [R], 8: [R], 9: [R], 10: [R], 11: [R],
+        5: [R], 6: [R], 7: [R], 8: [R], 9: [R], 10: [R], 11: [R]
     },
     "Bärlauch": {
-        3: [R], 4: [R], 5: [R],
+        3: [R], 4: [R], 5: [R]
     },
     "Schwarzwurzel": {
         1: [L], 2: [L], 3: [L], 4: [L],
-        10: [R, L], 11: [L], 12: [L],
+        10: [R, L], 11: [L], 12: [L]
     },
     "Topinambur": {
         1: [L], 2: [L], 3: [L], 4: [L],
-        10: [R, L], 11: [L], 12: [L],
+        10: [R, L], 11: [L], 12: [L]
     },
     "Fenchel": {
-        6: [R], 7: [R], 8: [R], 9: [R], 10: [R], 11: [R],
-    },
+        6: [R], 7: [R], 8: [R], 9: [R], 10: [R], 11: [R]
+    }
 }
 # fmt: on
 
@@ -272,7 +244,7 @@ ITEMS: dict[str, dict[int, list[str]]] = {
 def _validate_data() -> list[str]:
     """Sanity check der ITEMS-Struktur. Gibt eine Liste an Fehlermeldungen zurück."""
     errors: list[str] = []
-    valid_types = {R, L, I}
+    valid_types = {R, L}
     for name, months in ITEMS.items():
         if not months:
             errors.append(f"{name}: keine Monate definiert")
@@ -349,7 +321,7 @@ def main():
             new_entries = []
             for month, types in months_data.items():
                 for t in types:
-                    # Postgres-Enum erwartet die value-Strings (regional/storage/import)
+                    # Postgres-Enum erwartet die value-Strings (regional/storage)
                     new_entries.append((month, t))
 
             if args.dry_run:

--- a/backend/tests/test_seasonal.py
+++ b/backend/tests/test_seasonal.py
@@ -104,24 +104,6 @@ class TestCRUD:
         assert _types_for_month(data, 1) == ["storage"]
         assert "id" in data
 
-    def test_create_with_import_type(self, client, admin_headers):
-        """Regression: 'import' als Wert (Python-Enum-Member heißt 'import_', Value 'import')."""
-        response = client.post(
-            "/seasonal",
-            json={
-                "name": "Banane", "category": "fruit",
-                "availabilities": [
-                    {"month": 1, "types": ["import"]},
-                    {"month": 6, "types": ["regional", "import"]},
-                ],
-            },
-            headers=admin_headers,
-        )
-        assert response.status_code == 201, response.text
-        data = response.json()
-        assert _types_for_month(data, 1) == ["import"]
-        assert _types_for_month(data, 6) == ["regional", "import"]
-
     def test_create_duplicate_name(self, client, admin_headers, created_item, sample_payload):
         response = client.post("/seasonal", json=sample_payload, headers=admin_headers)
         assert response.status_code == 409
@@ -185,14 +167,14 @@ class TestCRUD:
             f"/seasonal/{created_item['id']}",
             json={
                 "availabilities": [
-                    {"month": 5, "types": ["regional", "import"]},
+                    {"month": 5, "types": ["regional", "storage"]},
                 ]
             },
             headers=admin_headers,
         )
         assert response.status_code == 200
         data = response.json()
-        assert _types_for_month(data, 5) == ["regional", "import"]
+        assert _types_for_month(data, 5) == ["regional", "storage"]
 
     def test_update_not_found(self, client, admin_headers):
         response = client.patch("/seasonal/99999", json={"notes": "x"}, headers=admin_headers)

--- a/frontend/src/pages/SeasonalCalendar.tsx
+++ b/frontend/src/pages/SeasonalCalendar.tsx
@@ -17,26 +17,22 @@ const MONTH_NAMES = ['Jän', 'Feb', 'Mär', 'Apr', 'Mai', 'Jun', 'Jul', 'Aug', '
 const AVAILABILITY_LABEL: Record<SeasonalAvailability, string> = {
   regional: 'Saison',
   storage: 'Lagerware',
-  import: 'Import',
 };
 
 const AVAILABILITY_COLOR: Record<SeasonalAvailability, string> = {
   regional: 'bg-green-600',
   storage: 'bg-amber-500',
-  import: 'bg-sky-600',
 };
 
 // Hex-Werte für inline gradient backgrounds (entsprechen den Tailwind-Farben oben)
 const AVAILABILITY_HEX: Record<SeasonalAvailability, string> = {
   regional: '#16a34a',
   storage: '#f59e0b',
-  import: '#0284c7',
 };
 
 const AVAILABILITY_ORDER: Record<SeasonalAvailability, number> = {
   regional: 0,
   storage: 1,
-  import: 2,
 };
 
 type ViewMode = 'current' | 'month' | 'year';
@@ -206,20 +202,13 @@ export function SeasonalCalendar() {
                 >
                   Lager
                 </ViewBtn>
-                <ViewBtn
-                  active={availabilityFilter === 'import'}
-                  onClick={() => setAvailabilityFilter('import')}
-                  testid="avail-import"
-                >
-                  Import
-                </ViewBtn>
               </div>
             </div>
           </div>
 
           {/* Legende */}
           <div className="mt-4 flex flex-wrap gap-4 text-xs text-text-muted">
-            <LegendDot type="regional" /> <LegendDot type="storage" /> <LegendDot type="import" />
+            <LegendDot type="regional" /> <LegendDot type="storage" />
           </div>
         </div>
 

--- a/frontend/src/pages/SeasonalCalendarAdmin.tsx
+++ b/frontend/src/pages/SeasonalCalendarAdmin.tsx
@@ -22,19 +22,16 @@ const MONTH_SHORT = ['Jän', 'Feb', 'Mär', 'Apr', 'Mai', 'Jun', 'Jul', 'Aug', '
 const AVAILABILITY_OPTIONS: Array<{ value: SeasonalAvailability; label: string; color: string; hex: string }> = [
   { value: 'regional', label: 'Saison', color: 'bg-green-600', hex: '#16a34a' },
   { value: 'storage', label: 'Lager', color: 'bg-amber-500', hex: '#f59e0b' },
-  { value: 'import', label: 'Import', color: 'bg-sky-600', hex: '#0284c7' },
 ];
 
 const AVAILABILITY_HEX: Record<SeasonalAvailability, string> = {
   regional: '#16a34a',
   storage: '#f59e0b',
-  import: '#0284c7',
 };
 
 const AVAILABILITY_ORDER: Record<SeasonalAvailability, number> = {
   regional: 0,
   storage: 1,
-  import: 2,
 };
 
 type MonthsState = Record<number, SeasonalAvailability[]>;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -112,7 +112,7 @@ export interface RecipeInput {
 // ---------- Saisonkalender ----------
 
 export type SeasonalCategory = 'fruit' | 'vegetable';
-export type SeasonalAvailability = 'regional' | 'storage' | 'import';
+export type SeasonalAvailability = 'regional' | 'storage';
 
 export interface MonthAvailability {
   month: number; // 1..12


### PR DESCRIPTION
## Was

Entfernt den Verfügbarkeitstyp `import` aus dem Saisonkalender. Es bleiben nur `regional` und `storage`.

## Warum

Der Kalender war mit drei Typen + jeweils Multi-Type-Möglichkeit pro Monat unübersichtlich. `import` ist konzeptionell zudem schwach: ein Produkt ist entweder heimisch verfügbar (Saison oder Lager) oder eben nicht — Importware außerhalb der heimischen Saison ist die Default-Annahme und muss nicht explizit getrackt werden.

## Wie

- **Postgres-Enum schrumpfen** (Migration `35a7d963d996`): Rows mit `type='import'` löschen (112 Stück in Prod), Enum-Type über Text-Roundtrip auf `(regional, storage)` reduzieren. Downgrade fügt den Enum-Wert wieder hinzu, kann aber die gelöschten Rows nicht wiederherstellen.
- **Backend**: `SeasonalAvailability.import_` aus Enum, Sort-Maps und Tests entfernt.
- **Maintenance-Skript** `refine_seasonal_data.py`: `I = "import"` Konstante weg, alle Listen-Einträge mit `I` algorithmisch bereinigt (`[I]` → Eintrag weg, `[R, I]` → `[R]`, etc.). Doku-Header aktualisiert.
- **Frontend**: Filter-Button, Legend-Dot, Editor-Option, Type-Union und alle `Record<SeasonalAvailability, …>`-Maps (Color, Hex, Order, Label) bereinigt.

## Lokale Validierung

- Backend-Volltest auf frischer Postgres mit Migration: **255 passed, 3 skipped** (skips sind Cascade-Tests, die in SQLite nicht greifen — schon dokumentiert).
- Frontend `tsc -b --noEmit`: **TS OK**.
- Dry-Run von `refine_seasonal_data.py`: 17 Items würden mit reduzierten Einträgen aktualisiert; nur-Import-Items (Banane, Mango etc.) werden gar nicht mehr angefasst.

## Vor dem Pi-Deploy

DB-Backup ziehen (`./scripts/backup-db.sh`) bevor `docker compose up -d`. Migration ist daten-destruktiv für `import`-Rows.