### PR TITLE
fix(frontend): keep RecipeComments inside content container

### DIFF
--- a/frontend/src/pages/RecipeDetail.tsx
+++ b/frontend/src/pages/RecipeDetail.tsx
@@ -245,11 +245,11 @@ export function RecipeDetail() {
             )}
           </div>
         </div>
-      </div>
 
-      {user && (
-        <RecipeComments recipeId={recipe.id} currentUser={user} />
-      )}
+        {user && (
+          <RecipeComments recipeId={recipe.id} currentUser={user} />
+        )}
+      </div>
 
       {deleteModal && (
         <Modal


### PR DESCRIPTION
Comments section was outside the max-w-4xl wrapper and stretched full-width. Moves it inside so width and padding match titles, ingredients, and steps.