### PR TITLE
feat: recipe comment replies (1 level)

### DIFF
--- a/backend/alembic/versions/3dbd4892a161_add_recipe_comment_replies_and_recipe_.py
+++ b/backend/alembic/versions/3dbd4892a161_add_recipe_comment_replies_and_recipe_.py
@@ -1,0 +1,62 @@
+"""add recipe_comment_replies and recipe_comment_reply notification
+
+Revision ID: 3dbd4892a161
+Revises: ff8371c67db1
+Create Date: 2026-05-10 05:55:32.490525
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '3dbd4892a161'
+down_revision: Union[str, Sequence[str], None] = 'ff8371c67db1'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # Self-referential FK for nested-style replies (currently used flat: 1 level).
+    op.add_column(
+        'recipe_comments',
+        sa.Column('parent_id', sa.Integer(), nullable=True),
+    )
+    op.create_index(
+        op.f('ix_recipe_comments_parent_id'),
+        'recipe_comments',
+        ['parent_id'],
+        unique=False,
+    )
+    op.create_foreign_key(
+        'recipe_comments_parent_id_fkey',
+        'recipe_comments',
+        'recipe_comments',
+        ['parent_id'],
+        ['id'],
+        ondelete='CASCADE',
+    )
+    # Alembic autogenerate does NOT detect Postgres enum value additions, so do it manually.
+    # IF NOT EXISTS makes the migration idempotent (Postgres 12+).
+    op.execute(
+        "ALTER TYPE notification_type ADD VALUE IF NOT EXISTS 'recipe_comment_reply'"
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_constraint(
+        'recipe_comments_parent_id_fkey',
+        'recipe_comments',
+        type_='foreignkey',
+    )
+    op.drop_index(
+        op.f('ix_recipe_comments_parent_id'),
+        table_name='recipe_comments',
+    )
+    op.drop_column('recipe_comments', 'parent_id')
+    # Note: Postgres does not support DROP VALUE on enums without recreating the type.
+    # The 'recipe_comment_reply' value remains on downgrade — harmless if no rows use it.

--- a/backend/models.py
+++ b/backend/models.py
@@ -284,6 +284,12 @@ class RecipeComment(Base):
         ForeignKey("users.id", ondelete="SET NULL"),
         nullable=True,
     )
+    parent_id = Column(
+        Integer,
+        ForeignKey("recipe_comments.id", ondelete="CASCADE"),
+        nullable=True,
+        index=True,
+    )
     content = Column(String(2000), nullable=False)
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
     updated_at = Column(
@@ -296,6 +302,11 @@ class RecipeComment(Base):
 
     recipe = relationship("Recipe", backref="comments")
     user = relationship("User")
+    parent = relationship(
+        "RecipeComment",
+        remote_side="RecipeComment.id",
+        backref="replies",
+    )
 
     __table_args__ = (
         Index("ix_recipe_comments_recipe_created", "recipe_id", "created_at"),
@@ -356,6 +367,7 @@ import enum as _notif_enum
 class NotificationType(_notif_enum.Enum):
     """Notification-Typen. Werte werden als Postgres-Enum gespeichert."""
     recipe_comment = "recipe_comment"
+    recipe_comment_reply = "recipe_comment_reply"
 
 
 class Notification(Base):
@@ -379,6 +391,9 @@ class Notification(Base):
     # JSON-Payload mit typ-spezifischen Daten:
     # für recipe_comment: { "recipe_id": int, "recipe_title": str,
     #                       "comment_id": int, "actor_id": int, "actor_name": str }
+    # für recipe_comment_reply: { "recipe_id": int, "recipe_title": str,
+    #                             "comment_id": int, "parent_comment_id": int,
+    #                             "actor_id": int, "actor_name": str }
     payload = Column(JSON, nullable=False)
     read = Column(Boolean, nullable=False, default=False, server_default="false")
     created_at = Column(

--- a/backend/routers/notifications.py
+++ b/backend/routers/notifications.py
@@ -8,6 +8,8 @@ sodass künftige Notification-Typen ohne Schema-Änderung dazukommen können.
 Aktuell unterstützte Typen:
 - recipe_comment: jemand hat einen Kommentar zu einem Rezept verfasst,
   dessen Autor der Empfänger ist.
+- recipe_comment_reply: jemand hat auf einen Kommentar des Empfängers
+  geantwortet.
 """
 from typing import Optional
 
@@ -62,6 +64,45 @@ def create_recipe_comment_notification(
             "recipe_id": recipe_id,
             "recipe_title": recipe_title,
             "comment_id": comment_id,
+            "actor_id": actor_id,
+            "actor_name": actor_name,
+        },
+    )
+    db.add(notif)
+    db.flush()
+    return notif
+
+
+def create_recipe_comment_reply_notification(
+    db: Session,
+    *,
+    recipient_id: int,
+    actor_id: int,
+    actor_name: str,
+    recipe_id: int,
+    recipe_title: str,
+    comment_id: int,
+    parent_comment_id: int,
+) -> Optional[models.Notification]:
+    """
+    Reply-Notification für den Autor eines Kommentars, auf den geantwortet wurde.
+
+    Erzeugt KEINE Notification, wenn Empfänger == Akteur (User antwortet auf
+    eigenen Kommentar).
+
+    Wirft NICHT — Caller (try/except) ist für rollback im Fehlerfall verantwortlich.
+    """
+    if recipient_id == actor_id:
+        return None
+
+    notif = models.Notification(
+        user_id=recipient_id,
+        type=models.NotificationType.recipe_comment_reply,
+        payload={
+            "recipe_id": recipe_id,
+            "recipe_title": recipe_title,
+            "comment_id": comment_id,
+            "parent_comment_id": parent_comment_id,
             "actor_id": actor_id,
             "actor_name": actor_name,
         },

--- a/backend/routers/recipe_comments.py
+++ b/backend/routers/recipe_comments.py
@@ -1,10 +1,15 @@
+from typing import Optional
+
 from fastapi import APIRouter, Depends, HTTPException, Request
 from sqlalchemy.orm import Session, selectinload
 from pydantic import BaseModel, Field, field_validator
 
 from database import get_db
 from auth import require_member
-from routers.notifications import create_recipe_comment_notification
+from routers.notifications import (
+    create_recipe_comment_notification,
+    create_recipe_comment_reply_notification,
+)
 from rate_limit import limiter
 import models
 
@@ -15,6 +20,7 @@ router = APIRouter(prefix="/recipes", tags=["recipe_comments"])
 
 class CommentCreate(BaseModel):
     content: str = Field(min_length=1, max_length=2000)
+    parent_id: Optional[int] = None
 
     @field_validator("content")
     @classmethod
@@ -44,10 +50,37 @@ def _serialize_comment(c: models.RecipeComment) -> dict:
         "user_id": c.user_id,
         "user_name": c.user.name if c.user else "Gelöschter Nutzer",
         "content": c.content,
+        "parent_id": c.parent_id,
         "edited": c.edited,
         "created_at": c.created_at.isoformat(),
         "updated_at": c.updated_at.isoformat(),
     }
+
+
+def _build_comment_tree(comments: list[models.RecipeComment]) -> list[dict]:
+    """
+    Nimmt eine flache Liste aller Kommentare eines Rezepts und gibt nested zurück:
+    Top-Level-Kommentare mit `replies`-Array.
+
+    - Top-Level: chronologisch (created_at ASC, so wie aus der DB-Query gekommen).
+    - Replies: neuester zuerst (created_at DESC, ID-Tiebreaker bei gleichem Timestamp).
+    """
+    by_parent: dict[int, list[models.RecipeComment]] = {}
+    top_level: list[models.RecipeComment] = []
+    for c in comments:
+        if c.parent_id is None:
+            top_level.append(c)
+        else:
+            by_parent.setdefault(c.parent_id, []).append(c)
+
+    result = []
+    for parent in top_level:
+        replies = by_parent.get(parent.id, [])
+        replies.sort(key=lambda r: (r.created_at, r.id), reverse=True)
+        item = _serialize_comment(parent)
+        item["replies"] = [_serialize_comment(r) for r in replies]
+        result.append(item)
+    return result
 
 
 def _get_comment_or_404(db: Session, recipe_id: int, comment_id: int) -> models.RecipeComment:
@@ -89,7 +122,7 @@ def list_comments(
         .order_by(models.RecipeComment.created_at.asc())
         .all()
     )
-    return [_serialize_comment(c) for c in comments]
+    return _build_comment_tree(comments)
 
 
 @router.post("/{recipe_id}/comments", status_code=201)
@@ -105,20 +138,53 @@ def create_comment(
     if not recipe:
         raise HTTPException(status_code=404, detail="Rezept nicht gefunden")
 
+    # parent_id validieren: existiert, gleiches Rezept, ist Top-Level (flach: 1 Level)
+    parent_comment: Optional[models.RecipeComment] = None
+    if payload.parent_id is not None:
+        parent_comment = (
+            db.query(models.RecipeComment)
+            .filter(
+                models.RecipeComment.id == payload.parent_id,
+                models.RecipeComment.recipe_id == recipe_id,
+            )
+            .first()
+        )
+        if not parent_comment:
+            raise HTTPException(status_code=404, detail="Parent-Kommentar nicht gefunden")
+        if parent_comment.parent_id is not None:
+            raise HTTPException(
+                status_code=400,
+                detail="Antworten auf Antworten sind nicht erlaubt",
+            )
+
     comment = models.RecipeComment(
         recipe_id=recipe_id,
         user_id=current_user.id,
+        parent_id=parent_comment.id if parent_comment else None,
         content=payload.content.strip(),
     )
     db.add(comment)
     db.commit()
     db.refresh(comment)
-    # User für Serialisierung nachladen
     db.refresh(comment, attribute_names=["user"])
 
-    # Notification für Recipe-Author anlegen (außer er kommentiert selbst)
-    if recipe.author_id and recipe.author_id != current_user.id:
-        try:
+    # Notifications: Helper machen Self-Check selbst (recipient_id == actor_id → None).
+    # Dedupe-Regel: wenn Rezept-Owner == Parent-Author, NUR Reply-Notification senden
+    # (spezifischer; vermeidet Doppel-Benachrichtigung).
+    parent_author_id = parent_comment.user_id if parent_comment else None
+    try:
+        if parent_comment is not None and parent_author_id is not None:
+            create_recipe_comment_reply_notification(
+                db,
+                recipient_id=parent_author_id,
+                actor_id=current_user.id,
+                actor_name=current_user.name,
+                recipe_id=recipe.id,
+                recipe_title=recipe.title,
+                comment_id=comment.id,
+                parent_comment_id=parent_comment.id,
+            )
+        if recipe.author_id and recipe.author_id != parent_author_id:
             create_recipe_comment_notification(
                 db,
                 recipient_id=recipe.author_id,
@@ -128,10 +194,10 @@ def create_comment(
                 recipe_title=recipe.title,
                 comment_id=comment.id,
             )
-            db.commit()
-        except Exception:
-            # Notification-Fehler darf den Comment-Create nicht killen
-            db.rollback()
+        db.commit()
+    except Exception:
+        # Notification-Fehler darf den Comment-Create nicht killen
+        db.rollback()
 
     return _serialize_comment(comment)
 
@@ -164,6 +230,10 @@ def delete_comment(
     db: Session = Depends(get_db),
     current_user: models.User = Depends(require_member),
 ):
+    """
+    Löscht einen Kommentar. Bei Top-Level-Kommentaren werden alle Replies
+    via DB-Cascade (ON DELETE CASCADE auf parent_id) automatisch mit-gelöscht.
+    """
     comment = _get_comment_or_404(db, recipe_id, comment_id)
     if not _can_modify(comment, current_user):
         raise HTTPException(status_code=403, detail="Nicht autorisiert")

--- a/backend/tests/test_notifications.py
+++ b/backend/tests/test_notifications.py
@@ -407,3 +407,204 @@ class TestRecipeCommentCount:
         by_id = {r["id"]: r for r in items}
         assert by_id[r_a.id]["comment_count"] == 3
         assert by_id[r_b.id]["comment_count"] == 1
+
+
+# ---------- Reply-Notifications ----------
+
+class TestReplyCreatesNotification:
+    def test_reply_notifies_parent_author(self, client, db_session, test_user):
+        """Reply auf einen fremden Kommentar erzeugt eine recipe_comment_reply-Notif
+        für den Parent-Comment-Autor."""
+        owner = _make_user(db_session, "owner@example.com", "Owner")
+        recipe = _make_recipe(db_session, author=owner)
+
+        # test_user legt Top-Level an (löst recipe_comment für owner aus)
+        parent_resp = client.post(
+            f"/recipes/{recipe.id}/comments",
+            headers=_headers_for(test_user),
+            json={"content": "Top-Level"},
+        )
+        assert parent_resp.status_code == 201
+        parent_id = parent_resp.json()["id"]
+
+        # Dritter User antwortet
+        replier = _make_user(db_session, "replier@example.com", "Replier")
+        reply_resp = client.post(
+            f"/recipes/{recipe.id}/comments",
+            headers=_headers_for(replier),
+            json={"content": "Antwort", "parent_id": parent_id},
+        )
+        assert reply_resp.status_code == 201
+        reply_id = reply_resp.json()["id"]
+
+        # test_user (Parent-Autor) hat genau eine Reply-Notif
+        reply_notifs = (
+            db_session.query(models.Notification)
+            .filter(
+                models.Notification.user_id == test_user.id,
+                models.Notification.type
+                == models.NotificationType.recipe_comment_reply,
+            )
+            .all()
+        )
+        assert len(reply_notifs) == 1
+        n = reply_notifs[0]
+        assert n.read is False
+        assert n.payload["recipe_id"] == recipe.id
+        assert n.payload["recipe_title"] == recipe.title
+        assert n.payload["comment_id"] == reply_id
+        assert n.payload["parent_comment_id"] == parent_id
+        assert n.payload["actor_id"] == replier.id
+        assert n.payload["actor_name"] == "Replier"
+
+    def test_self_reply_does_not_notify(self, client, db_session, test_user):
+        """Reply auf eigenen Kommentar erzeugt KEINE Reply-Notif."""
+        owner = _make_user(db_session, "owner@example.com", "Owner")
+        recipe = _make_recipe(db_session, author=owner)
+
+        parent_resp = client.post(
+            f"/recipes/{recipe.id}/comments",
+            headers=_headers_for(test_user),
+            json={"content": "Top"},
+        )
+        parent_id = parent_resp.json()["id"]
+
+        client.post(
+            f"/recipes/{recipe.id}/comments",
+            headers=_headers_for(test_user),
+            json={"content": "Selbst-Antwort", "parent_id": parent_id},
+        )
+
+        reply_notifs = (
+            db_session.query(models.Notification)
+            .filter(
+                models.Notification.user_id == test_user.id,
+                models.Notification.type
+                == models.NotificationType.recipe_comment_reply,
+            )
+            .all()
+        )
+        assert reply_notifs == []
+
+    def test_reply_in_third_party_recipe_notifies_owner_and_parent_author(
+        self, client, db_session, test_user
+    ):
+        """Reply in fremdem Rezept: Parent-Autor und Recipe-Owner sind verschieden
+        → beide bekommen eine Notif (Reply-Typ bzw. Comment-Typ)."""
+        owner = _make_user(db_session, "owner@example.com", "Owner")
+        recipe = _make_recipe(db_session, author=owner)
+
+        # test_user legt Top-Level an
+        parent_resp = client.post(
+            f"/recipes/{recipe.id}/comments",
+            headers=_headers_for(test_user),
+            json={"content": "Top"},
+        )
+        parent_id = parent_resp.json()["id"]
+        # Owner sollte exakt 1 recipe_comment-Notif haben
+        assert (
+            db_session.query(models.Notification).filter_by(user_id=owner.id).count()
+            == 1
+        )
+
+        # Dritter antwortet
+        replier = _make_user(db_session, "replier@example.com", "Replier")
+        client.post(
+            f"/recipes/{recipe.id}/comments",
+            headers=_headers_for(replier),
+            json={"content": "Antwort", "parent_id": parent_id},
+        )
+
+        # test_user (Parent-Autor): 1 Reply-Notif
+        test_user_notifs = (
+            db_session.query(models.Notification)
+            .filter_by(user_id=test_user.id)
+            .all()
+        )
+        assert len(test_user_notifs) == 1
+        assert test_user_notifs[0].type == models.NotificationType.recipe_comment_reply
+
+        # Owner: 2 Comment-Notifs (Top-Level + Reply, beide Typ recipe_comment)
+        owner_notifs = (
+            db_session.query(models.Notification).filter_by(user_id=owner.id).all()
+        )
+        assert len(owner_notifs) == 2
+        assert all(
+            n.type == models.NotificationType.recipe_comment for n in owner_notifs
+        )
+
+    def test_dedupe_when_owner_is_parent_author(self, client, db_session, test_user):
+        """Wenn Recipe-Owner == Parent-Comment-Autor: nur Reply-Notif, keine
+        zusätzliche Comment-Notif (vermeidet Doppel-Benachrichtigung)."""
+        recipe = _make_recipe(db_session, author=test_user)
+
+        # test_user legt eigenen Top-Level an (kein Notif für sich)
+        parent_resp = client.post(
+            f"/recipes/{recipe.id}/comments",
+            headers=_headers_for(test_user),
+            json={"content": "Top"},
+        )
+        parent_id = parent_resp.json()["id"]
+        assert (
+            db_session.query(models.Notification)
+            .filter_by(user_id=test_user.id)
+            .count()
+            == 0
+        )
+
+        replier = _make_user(db_session, "replier@example.com", "Replier")
+        client.post(
+            f"/recipes/{recipe.id}/comments",
+            headers=_headers_for(replier),
+            json={"content": "Antwort", "parent_id": parent_id},
+        )
+
+        # GENAU eine Notif: Reply, nicht Reply + Comment
+        notifs = (
+            db_session.query(models.Notification)
+            .filter_by(user_id=test_user.id)
+            .all()
+        )
+        assert len(notifs) == 1
+        assert notifs[0].type == models.NotificationType.recipe_comment_reply
+
+    def test_owner_self_reply_in_own_recipe_no_self_notif(
+        self, client, db_session, test_user
+    ):
+        """Owner antwortet auf fremden Kommentar in eigenem Rezept → keine Self-Notif."""
+        recipe = _make_recipe(db_session, author=test_user)
+
+        commenter = _make_user(db_session, "commenter@example.com", "Commenter")
+        parent_resp = client.post(
+            f"/recipes/{recipe.id}/comments",
+            headers=_headers_for(commenter),
+            json={"content": "Top"},
+        )
+        parent_id = parent_resp.json()["id"]
+
+        # Owner (test_user) antwortet
+        client.post(
+            f"/recipes/{recipe.id}/comments",
+            headers=_headers_for(test_user),
+            json={"content": "Antwort", "parent_id": parent_id},
+        )
+
+        # commenter bekommt Reply-Notif
+        commenter_notifs = (
+            db_session.query(models.Notification)
+            .filter_by(user_id=commenter.id)
+            .all()
+        )
+        assert len(commenter_notifs) == 1
+        assert (
+            commenter_notifs[0].type == models.NotificationType.recipe_comment_reply
+        )
+
+        # test_user hat NUR die Original-Comment-Notif, keine Self-Reply-Notif
+        test_user_notifs = (
+            db_session.query(models.Notification)
+            .filter_by(user_id=test_user.id)
+            .all()
+        )
+        assert len(test_user_notifs) == 1
+        assert test_user_notifs[0].type == models.NotificationType.recipe_comment

--- a/backend/tests/test_recipe_comments.py
+++ b/backend/tests/test_recipe_comments.py
@@ -316,3 +316,203 @@ class TestCascadeBehavior:
         assert len(data) == 1
         assert data[0]["user_name"] == "Gelöschter Nutzer"
         assert data[0]["user_id"] is None
+
+
+# ---------- Replies (parent_id) ----------
+
+class TestCreateReply:
+    def test_member_creates_reply(
+        self, client, auth_headers, recipe, test_user, db_session
+    ):
+        parent = _make_comment(db_session, recipe.id, test_user.id, "Top-Level")
+        response = client.post(
+            f"/recipes/{recipe.id}/comments",
+            headers=auth_headers,
+            json={"content": "Antwort", "parent_id": parent.id},
+        )
+        assert response.status_code == 201
+        body = response.json()
+        assert body["content"] == "Antwort"
+        assert body["parent_id"] == parent.id
+
+    def test_explicit_null_parent_creates_top_level(self, client, auth_headers, recipe):
+        response = client.post(
+            f"/recipes/{recipe.id}/comments",
+            headers=auth_headers,
+            json={"content": "Top", "parent_id": None},
+        )
+        assert response.status_code == 201
+        assert response.json()["parent_id"] is None
+
+    def test_nonexistent_parent_returns_404(self, client, auth_headers, recipe):
+        response = client.post(
+            f"/recipes/{recipe.id}/comments",
+            headers=auth_headers,
+            json={"content": "x", "parent_id": 99999},
+        )
+        assert response.status_code == 404
+
+    def test_parent_in_other_recipe_returns_404(
+        self, client, auth_headers, recipe, test_user, db_session
+    ):
+        # Anderes Rezept mit Comment darin
+        other_recipe = models.Recipe(
+            title="Other",
+            servings=1,
+            servings_unit="x",
+            author_id=test_user.id,
+        )
+        db_session.add(other_recipe)
+        db_session.commit()
+        db_session.refresh(other_recipe)
+        other_parent = _make_comment(
+            db_session, other_recipe.id, test_user.id, "Foreign"
+        )
+
+        response = client.post(
+            f"/recipes/{recipe.id}/comments",
+            headers=auth_headers,
+            json={"content": "x", "parent_id": other_parent.id},
+        )
+        assert response.status_code == 404
+
+    def test_reply_to_reply_rejected(
+        self, client, auth_headers, recipe, test_user, db_session
+    ):
+        parent = _make_comment(db_session, recipe.id, test_user.id, "L0")
+        first_reply_resp = client.post(
+            f"/recipes/{recipe.id}/comments",
+            headers=auth_headers,
+            json={"content": "L1", "parent_id": parent.id},
+        )
+        assert first_reply_resp.status_code == 201
+        first_reply_id = first_reply_resp.json()["id"]
+
+        # Reply zu Reply (ungültig — flach: 1 Level)
+        response = client.post(
+            f"/recipes/{recipe.id}/comments",
+            headers=auth_headers,
+            json={"content": "L2", "parent_id": first_reply_id},
+        )
+        assert response.status_code == 400
+
+    def test_guest_cannot_reply(
+        self, client, guest_headers, recipe, test_user, db_session
+    ):
+        parent = _make_comment(db_session, recipe.id, test_user.id, "Top")
+        response = client.post(
+            f"/recipes/{recipe.id}/comments",
+            headers=guest_headers,
+            json={"content": "Antwort", "parent_id": parent.id},
+        )
+        assert response.status_code == 403
+
+
+# ---------- GET mit Reply-Tree ----------
+
+class TestListWithReplies:
+    def test_top_level_has_empty_replies_array(
+        self, client, auth_headers, recipe, test_user, db_session
+    ):
+        _make_comment(db_session, recipe.id, test_user.id, "Solo")
+        response = client.get(f"/recipes/{recipe.id}/comments", headers=auth_headers)
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["replies"] == []
+
+    def test_replies_grouped_under_parent(
+        self, client, auth_headers, recipe, test_user, db_session
+    ):
+        parent = _make_comment(db_session, recipe.id, test_user.id, "Top-Level")
+        client.post(
+            f"/recipes/{recipe.id}/comments",
+            headers=auth_headers,
+            json={"content": "Reply 1", "parent_id": parent.id},
+        )
+        client.post(
+            f"/recipes/{recipe.id}/comments",
+            headers=auth_headers,
+            json={"content": "Reply 2", "parent_id": parent.id},
+        )
+
+        response = client.get(f"/recipes/{recipe.id}/comments", headers=auth_headers)
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["content"] == "Top-Level"
+        assert len(data[0]["replies"]) == 2
+
+    def test_replies_sorted_newest_first(
+        self, client, auth_headers, recipe, test_user, db_session
+    ):
+        parent = _make_comment(db_session, recipe.id, test_user.id, "Top")
+        # Auto-Increment-ID ist Tiebreaker bei identischem created_at
+        client.post(
+            f"/recipes/{recipe.id}/comments",
+            headers=auth_headers,
+            json={"content": "Aelter", "parent_id": parent.id},
+        )
+        client.post(
+            f"/recipes/{recipe.id}/comments",
+            headers=auth_headers,
+            json={"content": "Neuer", "parent_id": parent.id},
+        )
+
+        response = client.get(f"/recipes/{recipe.id}/comments", headers=auth_headers)
+        replies = response.json()[0]["replies"]
+        assert replies[0]["content"] == "Neuer"
+        assert replies[1]["content"] == "Aelter"
+
+    def test_top_level_chronological(
+        self, client, auth_headers, recipe, test_user, db_session
+    ):
+        _make_comment(db_session, recipe.id, test_user.id, "Erster")
+        _make_comment(db_session, recipe.id, test_user.id, "Zweiter")
+        response = client.get(f"/recipes/{recipe.id}/comments", headers=auth_headers)
+        data = response.json()
+        assert data[0]["content"] == "Erster"
+        assert data[1]["content"] == "Zweiter"
+
+    def test_replies_not_at_top_level(
+        self, client, auth_headers, recipe, test_user, db_session
+    ):
+        """Replies dürfen NICHT als eigenständiger Top-Level-Eintrag erscheinen."""
+        parent = _make_comment(db_session, recipe.id, test_user.id, "Top")
+        client.post(
+            f"/recipes/{recipe.id}/comments",
+            headers=auth_headers,
+            json={"content": "R1", "parent_id": parent.id},
+        )
+        response = client.get(f"/recipes/{recipe.id}/comments", headers=auth_headers)
+        data = response.json()
+        # Genau ein Top-Level — Reply ist im replies-Array, nicht oben
+        assert len(data) == 1
+        assert {item["content"] for item in data} == {"Top"}
+
+
+# ---------- DELETE mit Reply ----------
+
+class TestDeleteReply:
+    def test_owner_deletes_own_reply_parent_remains(
+        self, client, auth_headers, recipe, test_user, db_session
+    ):
+        parent = _make_comment(db_session, recipe.id, test_user.id, "Top")
+        reply_resp = client.post(
+            f"/recipes/{recipe.id}/comments",
+            headers=auth_headers,
+            json={"content": "Reply", "parent_id": parent.id},
+        )
+        reply_id = reply_resp.json()["id"]
+
+        del_resp = client.delete(
+            f"/recipes/{recipe.id}/comments/{reply_id}",
+            headers=auth_headers,
+        )
+        assert del_resp.status_code == 204
+        assert (
+            db_session.query(models.RecipeComment).filter_by(id=reply_id).first()
+            is None
+        )
+        assert (
+            db_session.query(models.RecipeComment).filter_by(id=parent.id).first()
+            is not None
+        )

--- a/frontend/src/api/recipeComments.ts
+++ b/frontend/src/api/recipeComments.ts
@@ -12,10 +12,11 @@ export async function listComments(recipeId: number): Promise<RecipeComment[]> {
 export async function createComment(
   recipeId: number,
   content: string,
+  parentId: number | null = null,
 ): Promise<RecipeComment> {
   return api<RecipeComment>(`/recipes/${recipeId}/comments`, {
     method: 'POST',
-    body: JSON.stringify({ content }),
+    body: JSON.stringify({ content, parent_id: parentId }),
   });
 }
 

--- a/frontend/src/components/NotificationBell.tsx
+++ b/frontend/src/components/NotificationBell.tsx
@@ -28,6 +28,8 @@ function notificationText(n: Notification): string {
   switch (n.type) {
     case 'recipe_comment':
       return `${n.payload.actor_name} hat „${n.payload.recipe_title}“ kommentiert.`;
+    case 'recipe_comment_reply':
+      return `${n.payload.actor_name} hat auf deinen Kommentar zu „${n.payload.recipe_title}“ geantwortet.`;
     default:
       return 'Neue Benachrichtigung';
   }
@@ -36,6 +38,7 @@ function notificationText(n: Notification): string {
 function notificationLink(n: Notification): string {
   switch (n.type) {
     case 'recipe_comment':
+    case 'recipe_comment_reply':
       return `/rezepte/${n.payload.recipe_id}#comment-${n.payload.comment_id}`;
     default:
       return '/';

--- a/frontend/src/components/RecipeComments.tsx
+++ b/frontend/src/components/RecipeComments.tsx
@@ -31,11 +31,16 @@ export function RecipeComments({ recipeId, currentUser }: Props) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
 
-  // Neuer Kommentar
+  // Neuer Top-Level-Kommentar
   const [newContent, setNewContent] = useState('');
   const [submitting, setSubmitting] = useState(false);
 
-  // Edit-State
+  // Reply-State (max. eine offene Reply-Form gleichzeitig)
+  const [replyingToId, setReplyingToId] = useState<number | null>(null);
+  const [replyContent, setReplyContent] = useState('');
+  const [submittingReply, setSubmittingReply] = useState(false);
+
+  // Edit-State (greift auf beide Levels: Top-Level + Replies)
   const [editingId, setEditingId] = useState<number | null>(null);
   const [editContent, setEditContent] = useState('');
   const [savingEdit, setSavingEdit] = useState(false);
@@ -53,15 +58,58 @@ export function RecipeComments({ recipeId, currentUser }: Props) {
     return () => { cancelled = true; };
   }, [recipeId]);
 
-  async function handleSubmit(e: React.FormEvent) {
+  // Tree-Update-Helper (flach, max. 1 Level Replies)
+
+  function addTopLevel(created: RecipeComment) {
+    setComments(prev => [...prev, created]);
+  }
+
+  function addReplyToTree(created: RecipeComment) {
+    if (created.parent_id === null) return;
+    setComments(prev => prev.map(c =>
+      c.id === created.parent_id
+        ? { ...c, replies: [created, ...(c.replies ?? [])] }
+        : c,
+    ));
+  }
+
+  function updateInTree(updated: RecipeComment) {
+    setComments(prev => prev.map(c => {
+      if (c.id === updated.id) {
+        // Top-Level updated: replies-Array beibehalten
+        return { ...updated, replies: c.replies };
+      }
+      if (c.replies?.some(r => r.id === updated.id)) {
+        return {
+          ...c,
+          replies: c.replies.map(r => r.id === updated.id ? updated : r),
+        };
+      }
+      return c;
+    }));
+  }
+
+  function removeFromTree(id: number) {
+    setComments(prev => prev
+      .filter(c => c.id !== id)
+      .map(c => c.replies
+        ? { ...c, replies: c.replies.filter(r => r.id !== id) }
+        : c,
+      ),
+    );
+  }
+
+  // Submit-Handler
+
+  async function handleSubmitTopLevel(e: React.FormEvent) {
     e.preventDefault();
     const trimmed = newContent.trim();
     if (!trimmed) return;
     setSubmitting(true);
     setError('');
     try {
-      const created = await createComment(recipeId, trimmed);
-      setComments(prev => [...prev, created]);
+      const created = await createComment(recipeId, trimmed, null);
+      addTopLevel(created);
       setNewContent('');
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Fehler beim Senden');
@@ -69,6 +117,35 @@ export function RecipeComments({ recipeId, currentUser }: Props) {
       setSubmitting(false);
     }
   }
+
+  function startReply(parent: RecipeComment) {
+    setReplyingToId(parent.id);
+    // @-Mention nur als Display-Text vorausfüllen
+    setReplyContent(`@${parent.user_name} `);
+  }
+
+  function cancelReply() {
+    setReplyingToId(null);
+    setReplyContent('');
+  }
+
+  async function submitReply(parentId: number) {
+    const trimmed = replyContent.trim();
+    if (!trimmed) return;
+    setSubmittingReply(true);
+    setError('');
+    try {
+      const created = await createComment(recipeId, trimmed, parentId);
+      addReplyToTree(created);
+      cancelReply();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Fehler beim Senden');
+    } finally {
+      setSubmittingReply(false);
+    }
+  }
+
+  // Edit-Handler
 
   function startEdit(c: RecipeComment) {
     setEditingId(c.id);
@@ -87,7 +164,7 @@ export function RecipeComments({ recipeId, currentUser }: Props) {
     setError('');
     try {
       const updated = await updateComment(recipeId, commentId, trimmed);
-      setComments(prev => prev.map(c => c.id === commentId ? updated : c));
+      updateInTree(updated);
       cancelEdit();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Fehler beim Speichern');
@@ -96,12 +173,14 @@ export function RecipeComments({ recipeId, currentUser }: Props) {
     }
   }
 
+  // Delete-Handler
+
   async function confirmDelete() {
     if (deletingId === null) return;
     setError('');
     try {
       await deleteComment(recipeId, deletingId);
-      setComments(prev => prev.filter(c => c.id !== deletingId));
+      removeFromTree(deletingId);
       setDeletingId(null);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Fehler beim Löschen');
@@ -112,10 +191,99 @@ export function RecipeComments({ recipeId, currentUser }: Props) {
     return currentUser.is_admin || c.user_id === currentUser.id;
   }
 
+  // Comment-Block-Renderer für Top-Level UND Replies (gleicher Aufbau)
+  function renderCommentBlock(c: RecipeComment, isReply: boolean) {
+    return (
+      <div id={`comment-${c.id}`} className="border border-border rounded p-4 scroll-mt-24">
+        <div className="flex items-baseline justify-between gap-4 mb-2">
+          <div className="text-sm">
+            <span className="font-medium">{c.user_name}</span>
+            <span className="text-text-hint ml-2">
+              {formatDate(c.created_at)}
+              {c.edited && ' · bearbeitet'}
+            </span>
+          </div>
+          {editingId !== c.id && (
+            <div className="flex gap-2 text-xs">
+              {!isReply && (
+                <button
+                  type="button"
+                  onClick={() => startReply(c)}
+                  className="text-text-muted hover:text-accent"
+                >
+                  Antworten
+                </button>
+              )}
+              {canModify(c) && (
+                <>
+                  <button
+                    type="button"
+                    onClick={() => startEdit(c)}
+                    className="text-text-muted hover:text-accent"
+                  >
+                    Bearbeiten
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setDeletingId(c.id)}
+                    className="text-text-muted hover:text-red-600"
+                  >
+                    Löschen
+                  </button>
+                </>
+              )}
+            </div>
+          )}
+        </div>
+
+        {editingId === c.id ? (
+          <div>
+            <textarea
+              value={editContent}
+              onChange={e => setEditContent(e.target.value)}
+              maxLength={MAX_LEN}
+              rows={3}
+              className="w-full p-2 border border-border rounded text-sm resize-y bg-bg-primary"
+              disabled={savingEdit}
+            />
+            <div className="flex justify-end gap-2 mt-2">
+              <button
+                type="button"
+                onClick={cancelEdit}
+                disabled={savingEdit}
+                className="text-xs text-text-muted hover:text-text-primary px-3 py-1"
+              >
+                Abbrechen
+              </button>
+              <button
+                type="button"
+                onClick={() => saveEdit(c.id)}
+                disabled={savingEdit || !editContent.trim()}
+                className="text-xs bg-accent text-bg-primary px-3 py-1 rounded disabled:opacity-50"
+              >
+                {savingEdit ? 'Speichere …' : 'Speichern'}
+              </button>
+            </div>
+          </div>
+        ) : (
+          <p className="text-sm leading-relaxed whitespace-pre-wrap">
+            {c.content}
+          </p>
+        )}
+      </div>
+    );
+  }
+
+  // Total-Count inkl. Replies (matcht das Backend-comment_count-Feld)
+  const totalCount = comments.reduce(
+    (sum, c) => sum + 1 + (c.replies?.length ?? 0),
+    0,
+  );
+
   return (
     <div className="mt-12 pt-8 border-t border-border">
       <h2 className="text-sm font-medium uppercase tracking-wider text-text-muted mb-4">
-        Kommentare {comments.length > 0 && `(${comments.length})`}
+        Kommentare {totalCount > 0 && `(${totalCount})`}
       </h2>
 
       {error && (
@@ -124,7 +292,6 @@ export function RecipeComments({ recipeId, currentUser }: Props) {
         </div>
       )}
 
-      {/* Liste */}
       {loading ? (
         <p className="text-sm text-text-hint">Lade Kommentare …</p>
       ) : comments.length === 0 ? (
@@ -134,76 +301,65 @@ export function RecipeComments({ recipeId, currentUser }: Props) {
       ) : (
         <ul className="space-y-4 mb-8">
           {comments.map(c => (
-            <li id={`comment-${c.id}`} key={c.id} className="border border-border rounded p-4 scroll-mt-24">
-              <div className="flex items-baseline justify-between gap-4 mb-2">
-                <div className="text-sm">
-                  <span className="font-medium">{c.user_name}</span>
-                  <span className="text-text-hint ml-2">
-                    {formatDate(c.created_at)}
-                    {c.edited && ' · bearbeitet'}
-                  </span>
-                </div>
-                {canModify(c) && editingId !== c.id && (
-                  <div className="flex gap-2 text-xs">
-                    <button
-                      type="button"
-                      onClick={() => startEdit(c)}
-                      className="text-text-muted hover:text-accent"
-                    >
-                      Bearbeiten
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => setDeletingId(c.id)}
-                      className="text-text-muted hover:text-red-600"
-                    >
-                      Löschen
-                    </button>
-                  </div>
-                )}
-              </div>
+            <li key={c.id}>
+              {renderCommentBlock(c, false)}
 
-              {editingId === c.id ? (
-                <div>
+              {/* Reply-Form direkt unter dem Parent, vor den Replies */}
+              {replyingToId === c.id && (
+                <div className="mt-3 ml-6 pl-4 border-l-2 border-border">
                   <textarea
-                    value={editContent}
-                    onChange={e => setEditContent(e.target.value)}
+                    value={replyContent}
+                    onChange={e => setReplyContent(e.target.value)}
                     maxLength={MAX_LEN}
                     rows={3}
+                    placeholder="Antwort schreiben …"
                     className="w-full p-2 border border-border rounded text-sm resize-y bg-bg-primary"
-                    disabled={savingEdit}
+                    disabled={submittingReply}
+                    autoFocus
                   />
-                  <div className="flex justify-end gap-2 mt-2">
-                    <button
-                      type="button"
-                      onClick={cancelEdit}
-                      disabled={savingEdit}
-                      className="text-xs text-text-muted hover:text-text-primary px-3 py-1"
-                    >
-                      Abbrechen
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => saveEdit(c.id)}
-                      disabled={savingEdit || !editContent.trim()}
-                      className="text-xs bg-accent text-bg-primary px-3 py-1 rounded disabled:opacity-50"
-                    >
-                      {savingEdit ? 'Speichere …' : 'Speichern'}
-                    </button>
+                  <div className="flex items-center justify-between mt-2">
+                    <span className="text-xs text-text-hint">
+                      {replyContent.length} / {MAX_LEN}
+                    </span>
+                    <div className="flex gap-2">
+                      <button
+                        type="button"
+                        onClick={cancelReply}
+                        disabled={submittingReply}
+                        className="text-xs text-text-muted hover:text-text-primary px-3 py-1"
+                      >
+                        Abbrechen
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => submitReply(c.id)}
+                        disabled={submittingReply || !replyContent.trim()}
+                        className="text-xs bg-accent text-bg-primary px-3 py-1 rounded disabled:opacity-50"
+                      >
+                        {submittingReply ? 'Sende …' : 'Antworten'}
+                      </button>
+                    </div>
                   </div>
                 </div>
-              ) : (
-                <p className="text-sm leading-relaxed whitespace-pre-wrap">
-                  {c.content}
-                </p>
+              )}
+
+              {/* Replies — newest first, eingerückt mit linker Border */}
+              {c.replies && c.replies.length > 0 && (
+                <ul className="mt-3 ml-6 pl-4 border-l-2 border-border space-y-3">
+                  {c.replies.map(r => (
+                    <li key={r.id}>
+                      {renderCommentBlock(r, true)}
+                    </li>
+                  ))}
+                </ul>
               )}
             </li>
           ))}
         </ul>
       )}
 
-      {/* Eingabe */}
-      <form onSubmit={handleSubmit} className="space-y-2">
+      {/* Top-Level-Eingabe */}
+      <form onSubmit={handleSubmitTopLevel} className="space-y-2">
         <label htmlFor="new-comment" className="sr-only">
           Neuer Kommentar
         </label>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -174,9 +174,13 @@ export interface RecipeComment {
   user_id: number | null;
   user_name: string;
   content: string;
+  parent_id: number | null;
   edited: boolean;
   created_at: string;
   updated_at: string;
+  // Nur am Top-Level-Eintrag aus GET /recipes/{id}/comments gesetzt.
+  // POST-Response liefert das Feld NICHT — daher optional.
+  replies?: RecipeComment[];
 }
 
 // ---------- Foto-Tagebuch ----------
@@ -204,7 +208,7 @@ export interface DiaryEntryInput {
 
 // ---------- Notifications ----------
 
-export type NotificationType = 'recipe_comment';
+export type NotificationType = 'recipe_comment' | 'recipe_comment_reply';
 
 export interface RecipeCommentNotificationPayload {
   recipe_id: number;
@@ -214,10 +218,23 @@ export interface RecipeCommentNotificationPayload {
   actor_name: string;
 }
 
+export interface RecipeCommentReplyNotificationPayload {
+  recipe_id: number;
+  recipe_title: string;
+  comment_id: number;
+  parent_comment_id: number;
+  actor_id: number;
+  actor_name: string;
+}
+
+export type NotificationPayload =
+  | RecipeCommentNotificationPayload
+  | RecipeCommentReplyNotificationPayload;
+
 export interface Notification {
   id: number;
   type: NotificationType;
-  payload: RecipeCommentNotificationPayload; // erweitern, sobald weitere Typen dazukommen
+  payload: NotificationPayload;
   read: boolean;
   created_at: string;
 }


### PR DESCRIPTION
## Was

Reply-Funktion für Rezept-Kommentare (1 Level, flach).

## Wie

**Backend**
- Neue Spalte `recipe_comments.parent_id` (Self-FK, `ON DELETE CASCADE`)
- Neuer Notification-Typ `recipe_comment_reply` (Postgres-Enum-Value via `ALTER TYPE ... ADD VALUE IF NOT EXISTS`)
- `POST /recipes/{id}/comments` akzeptiert optionales `parent_id`; validiert, dass Parent existiert, im selben Rezept liegt und selbst Top-Level ist (kein Threading)
- `GET /recipes/{id}/comments` liefert Tree: Top-Level chronologisch, Replies neuester zuerst (mit ID-Tiebreaker)
- Notification-Dedupe: wenn Recipe-Owner == Parent-Comment-Autor, nur die spezifischere Reply-Notif senden, keine zusätzliche Comment-Notif
- Hard-Delete kaskadiert via DB (kein Code-Change in DELETE-Handler nötig)

**Frontend**
- "Antworten"-Button unter jedem Top-Level-Kommentar
- Inline-Reply-Form mit `@username `-Vorbefüllung (nur Display-Text, keine DB-Verknüpfung)
- Replies eingerückt mit linker Border-Trennlinie
- Comment-Count im Header inkludiert Replies
- `NotificationBell`: Reply-Branch in `notificationText` + `notificationLink` (gleicher Anchor `#comment-<id>`)

## Tests

- 12 neue Backend-Tests (Reply-Validierung, Tree-Sortierung, Notification-Dedupe, Self-Reply-Skip)
- Insgesamt 65 passed, 2 erwartete SQLite-Skips (Cascade-Verhalten — durch frische-DB-Migration-Test verifiziert)
- Migration-Roundtrip getestet: incremental upgrade, downgrade, re-upgrade, frische DB von 0
- TypeScript-Build clean (`tsc -b --noEmit`)
