### PR TITLE
feat: dark/light mode toggle

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,5 @@
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
+import { ThemeProvider } from './contexts/ThemeContext';
 import { Home } from './pages/Home';
 import { Login } from './pages/Login';
 import { Register } from './pages/Register';
@@ -25,6 +26,7 @@ import { AdminImpostor } from './pages/AdminImpostor';
 
 function App() {
   return (
+    <ThemeProvider>
     <BrowserRouter>
       <Routes>
         <Route path="/" element={<Home />} />
@@ -55,6 +57,7 @@ function App() {
         <Route path="*" element={<NotFound />} />
       </Routes>
     </BrowserRouter>
+    </ThemeProvider>
   );
 }
 

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -3,6 +3,7 @@ import { Link, useLocation } from 'react-router-dom';
 import { useAuth } from '../hooks/useAuth';
 import { Avatar } from './Avatar';
 import { NotificationBell } from './NotificationBell';
+import { ThemeToggle } from './ThemeToggle';
 
 export function Navbar() {
   const { user } = useAuth();
@@ -52,6 +53,7 @@ export function Navbar() {
         </div>
 
         <div className="flex items-center gap-2">
+          <ThemeToggle />
           {user && <NotificationBell />}
           {user ? (
             <Link

--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -1,0 +1,32 @@
+import { useTheme } from '../contexts/ThemeContext';
+
+export function ThemeToggle() {
+  const { theme, toggle } = useTheme();
+
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      aria-label={theme === 'dark' ? 'Light Mode aktivieren' : 'Dark Mode aktivieren'}
+      className="p-2 text-text-muted hover:text-text-primary transition-colors"
+    >
+      {theme === 'dark' ? (
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <circle cx="12" cy="12" r="5" />
+          <line x1="12" y1="1" x2="12" y2="3" />
+          <line x1="12" y1="21" x2="12" y2="23" />
+          <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
+          <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
+          <line x1="1" y1="12" x2="3" y2="12" />
+          <line x1="21" y1="12" x2="23" y2="12" />
+          <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
+          <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
+        </svg>
+      ) : (
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+        </svg>
+      )}
+    </button>
+  );
+}

--- a/frontend/src/contexts/ThemeContext.tsx
+++ b/frontend/src/contexts/ThemeContext.tsx
@@ -1,0 +1,34 @@
+import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
+
+type Theme = 'light' | 'dark';
+
+const ThemeContext = createContext<{ theme: Theme; toggle: () => void } | null>(null);
+
+function getInitialTheme(): Theme {
+  const stored = localStorage.getItem('theme');
+  if (stored === 'light' || stored === 'dark') return stored;
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+}
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setTheme] = useState<Theme>(getInitialTheme);
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme);
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const toggle = () => setTheme(t => (t === 'light' ? 'dark' : 'light'));
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggle }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) throw new Error('useTheme must be used within ThemeProvider');
+  return ctx;
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -30,3 +30,16 @@
     @apply bg-bg-primary text-text-primary;
   }
 }
+
+[data-theme="dark"] {
+  --color-bg-primary: #141414;
+  --color-bg-secondary: #1E1E1E;
+  --color-bg-tertiary: #2A2A2A;
+  --color-text-primary: #EFEFEF;
+  --color-text-muted: #9B9794;
+  --color-text-hint: #5A5A5A;
+  --color-accent: #EFEFEF;
+  --color-accent-hover: #9B9794;
+  --color-border: #2E2E2E;
+  --color-border-light: #252525;
+}


### PR DESCRIPTION
## Summary

- Neuer `ThemeToggle`-Button in der Navbar (links neben der Glocke)
- `ThemeContext` mit `localStorage`-Persistenz und `prefers-color-scheme`-Default
- Dark-Mode CSS-Variablen in `index.css` via `[data-theme=\"dark\"]` auf dem `html`-Element
- Kein neues Package — reine CSS-Variable-Overrides, kein Tailwind-Plugin nötig

## Test plan

- [ ] Light Mode: Mond-Icon sichtbar, Klick wechselt zu Dark Mode
- [ ] Dark Mode: Sonne-Icon sichtbar, Klick wechselt zu Light Mode
- [ ] `localStorage`-Persistenz: nach Page-Reload bleibt gewählter Mode erhalten
- [ ] System-Default: Browser mit Dark-Mode-Preference bekommt beim ersten Besuch direkt Dark Mode
- [ ] Alle bestehenden Seiten (Rezepte, Einkaufsliste, etc.) korrekt im Dark Mode gerendert

🤖 Generated with [Claude Code](https://claude.com/claude-code)