### PR TITLE
feat: admin Projektreferenzen

### DIFF
--- a/backend/alembic/versions/a8b1c2d3e4f5_add_project_references_table.py
+++ b/backend/alembic/versions/a8b1c2d3e4f5_add_project_references_table.py
@@ -1,0 +1,41 @@
+"""add project_references table
+
+Revision ID: a8b1c2d3e4f5
+Revises: f1a2b3c4d5e6
+Create Date: 2026-05-10 12:00:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = 'a8b1c2d3e4f5'
+down_revision: Union[str, Sequence[str], None] = 'f1a2b3c4d5e6'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'project_references',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('title', sa.String(length=200), nullable=False),
+        sa.Column('date_from', sa.Date(), nullable=False),
+        sa.Column('date_to', sa.Date(), nullable=True),
+        sa.Column('industry', sa.String(length=200), nullable=False),
+        sa.Column('contact', sa.String(length=200), nullable=False),
+        sa.Column('fte', sa.Float(), nullable=False),
+        sa.Column('topic', sa.Text(), nullable=False),
+        sa.Column('roles', sa.Text(), nullable=False),
+        sa.Column('responsibilities', sa.Text(), nullable=False),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+        sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index('ix_project_references_id', 'project_references', ['id'], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index('ix_project_references_id', table_name='project_references')
+    op.drop_table('project_references')

--- a/backend/alembic/versions/a8b1c2d3e4f5_add_project_references_table.py
+++ b/backend/alembic/versions/a8b1c2d3e4f5_add_project_references_table.py
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 
 
 revision: str = 'a8b1c2d3e4f5'
-down_revision: Union[str, Sequence[str], None] = 'f1a2b3c4d5e6'
+down_revision: Union[str, Sequence[str], None] = '3dbd4892a161'
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -6,7 +6,7 @@ from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware
 from database import Base, engine
 import models
-from routers import auth, shopping, admin, recipes, recipe_comments, tags, seasonal, settings, impostor, diary, notifications
+from routers import auth, shopping, admin, recipes, recipe_comments, tags, seasonal, settings, impostor, diary, notifications, projektreferenzen
 from rate_limit import limiter
 import os
 import logging
@@ -40,6 +40,7 @@ app.include_router(settings.router)
 app.include_router(impostor.router)
 app.include_router(diary.router)
 app.include_router(notifications.router)
+app.include_router(projektreferenzen.router)
 
 # Test-Only-Endpoints: NUR registrieren wenn ENVIRONMENT=test
 if os.getenv("ENVIRONMENT") == "test":

--- a/backend/models.py
+++ b/backend/models.py
@@ -409,3 +409,22 @@ class Notification(Base):
         Index("ix_notifications_user_read", "user_id", "read"),
     )
 
+
+# ============================================================
+
+class ProjectReference(Base):
+    __tablename__ = "project_references"
+
+    id = Column(Integer, primary_key=True, index=True)
+    title = Column(String(200), nullable=False)
+    date_from = Column(Date, nullable=False)
+    date_to = Column(Date, nullable=True)
+    industry = Column(String(200), nullable=False)
+    contact = Column(String(200), nullable=False)
+    fte = Column(Float, nullable=False)
+    topic = Column(Text, nullable=False)
+    roles = Column(Text, nullable=False)
+    responsibilities = Column(Text, nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
+

--- a/backend/routers/projektreferenzen.py
+++ b/backend/routers/projektreferenzen.py
@@ -1,0 +1,141 @@
+"""
+Projektreferenzen API (Admin only).
+
+- GET    /projektreferenzen/      — Alle Referenzen (sortiert nach date_from desc)
+- POST   /projektreferenzen/      — Neue Referenz anlegen
+- PATCH  /projektreferenzen/{id}  — Referenz bearbeiten
+- DELETE /projektreferenzen/{id}  — Referenz löschen
+"""
+
+from datetime import date, datetime
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field, field_validator
+from sqlalchemy.orm import Session
+
+from database import get_db
+from auth import require_admin
+import models
+
+router = APIRouter(prefix="/projektreferenzen", tags=["projektreferenzen"])
+
+
+# ---------- Schemas ----------
+
+class ProjectReferenceRead(BaseModel):
+    id: int
+    title: str
+    date_from: date
+    date_to: Optional[date]
+    industry: str
+    contact: str
+    fte: float
+    topic: str
+    roles: str
+    responsibilities: str
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class ProjectReferenceCreate(BaseModel):
+    title: str = Field(..., min_length=1, max_length=200)
+    date_from: date
+    date_to: Optional[date] = None
+    industry: str = Field(..., min_length=1, max_length=200)
+    contact: str = Field(..., min_length=1, max_length=200)
+    fte: float = Field(..., gt=0)
+    topic: str = Field(..., min_length=1)
+    roles: str = Field(..., min_length=1)
+    responsibilities: str = Field(..., min_length=1)
+
+    @field_validator("title", "industry", "contact", "topic", "roles", "responsibilities")
+    @classmethod
+    def strip_text(cls, v: str) -> str:
+        v = v.strip()
+        if not v:
+            raise ValueError("Darf nicht leer sein")
+        return v
+
+
+class ProjectReferenceUpdate(BaseModel):
+    title: Optional[str] = Field(None, min_length=1, max_length=200)
+    date_from: Optional[date] = None
+    date_to: Optional[date] = None
+    industry: Optional[str] = Field(None, min_length=1, max_length=200)
+    contact: Optional[str] = Field(None, min_length=1, max_length=200)
+    fte: Optional[float] = Field(None, gt=0)
+    topic: Optional[str] = Field(None, min_length=1)
+    roles: Optional[str] = Field(None, min_length=1)
+    responsibilities: Optional[str] = Field(None, min_length=1)
+
+    @field_validator("title", "industry", "contact", "topic", "roles", "responsibilities")
+    @classmethod
+    def strip_text(cls, v):
+        if v is None:
+            return v
+        v = v.strip()
+        if not v:
+            raise ValueError("Darf nicht leer sein")
+        return v
+
+
+# ---------- Endpoints ----------
+
+@router.get("/", response_model=list[ProjectReferenceRead])
+def list_references(
+    db: Session = Depends(get_db),
+    user: models.User = Depends(require_admin),
+):
+    return (
+        db.query(models.ProjectReference)
+        .order_by(models.ProjectReference.date_from.desc(), models.ProjectReference.id.desc())
+        .all()
+    )
+
+
+@router.post("/", response_model=ProjectReferenceRead, status_code=status.HTTP_201_CREATED)
+def create_reference(
+    payload: ProjectReferenceCreate,
+    db: Session = Depends(get_db),
+    user: models.User = Depends(require_admin),
+):
+    ref = models.ProjectReference(**payload.model_dump())
+    db.add(ref)
+    db.commit()
+    db.refresh(ref)
+    return ref
+
+
+@router.patch("/{ref_id}", response_model=ProjectReferenceRead)
+def update_reference(
+    ref_id: int,
+    payload: ProjectReferenceUpdate,
+    db: Session = Depends(get_db),
+    user: models.User = Depends(require_admin),
+):
+    ref = db.get(models.ProjectReference, ref_id)
+    if not ref:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Referenz nicht gefunden")
+
+    for field, value in payload.model_dump(exclude_unset=True).items():
+        setattr(ref, field, value)
+
+    db.commit()
+    db.refresh(ref)
+    return ref
+
+
+@router.delete("/{ref_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_reference(
+    ref_id: int,
+    db: Session = Depends(get_db),
+    user: models.User = Depends(require_admin),
+):
+    ref = db.get(models.ProjectReference, ref_id)
+    if not ref:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Referenz nicht gefunden")
+    db.delete(ref)
+    db.commit()

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -23,6 +23,7 @@ import { SeasonalCalendar } from './pages/SeasonalCalendar';
 import { SeasonalCalendarAdmin } from './pages/SeasonalCalendarAdmin';
 import { Impostor } from './pages/Impostor';
 import { AdminImpostor } from './pages/AdminImpostor';
+import { AdminProjektreferenzen } from './pages/AdminProjektreferenzen';
 
 function App() {
   return (
@@ -48,6 +49,7 @@ function App() {
         <Route path="/admin/tags" element={<AdminTags />} />
         <Route path="/admin/saisonkalender" element={<SeasonalCalendarAdmin />} />
         <Route path="/admin/impostor" element={<AdminImpostor />} />
+        <Route path="/admin/projektreferenzen" element={<AdminProjektreferenzen />} />
         <Route path="/admin/einstellungen" element={<AdminSettings />} />
         <Route path="/forgot-password" element={<ForgotPassword />} />
         <Route path="/reset-password" element={<ResetPassword />} />

--- a/frontend/src/api/projektreferenzen.ts
+++ b/frontend/src/api/projektreferenzen.ts
@@ -1,0 +1,29 @@
+import { api } from '../lib/api';
+import type { ProjectReference, ProjectReferenceInput } from '../types';
+
+export async function adminListProjektreferenzen(): Promise<ProjectReference[]> {
+  return api<ProjectReference[]>('/projektreferenzen/');
+}
+
+export async function adminCreateProjektreferenz(
+  payload: ProjectReferenceInput,
+): Promise<ProjectReference> {
+  return api<ProjectReference>('/projektreferenzen/', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function adminUpdateProjektreferenz(
+  id: number,
+  payload: Partial<ProjectReferenceInput>,
+): Promise<ProjectReference> {
+  return api<ProjectReference>(`/projektreferenzen/${id}`, {
+    method: 'PATCH',
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function adminDeleteProjektreferenz(id: number): Promise<void> {
+  return api<void>(`/projektreferenzen/${id}`, { method: 'DELETE' });
+}

--- a/frontend/src/components/AdminLayout.tsx
+++ b/frontend/src/components/AdminLayout.tsx
@@ -44,6 +44,7 @@ export function AdminLayout({ children }: Props) {
           <NavLink to="/admin/tags" className={tabClass}>Tags</NavLink>
           <NavLink to="/admin/saisonkalender" className={tabClass}>Saisonkalender</NavLink>
           <NavLink to="/admin/impostor" className={tabClass}>Impostor</NavLink>
+          <NavLink to="/admin/projektreferenzen" className={tabClass}>Projektreferenzen</NavLink>
           <NavLink to="/admin/einstellungen" className={tabClass}>Einstellungen</NavLink>
         </div>
         {children}

--- a/frontend/src/pages/AdminProjektreferenzen.tsx
+++ b/frontend/src/pages/AdminProjektreferenzen.tsx
@@ -100,46 +100,40 @@ export function AdminProjektreferenzen() {
     setForm((prev) => ({ ...prev, [field]: value }));
   }
 
-  function buildPayload() {
+  function buildPayload(): ProjectReferenceInput | null {
     const fte = parseFloat(form.fte);
-    if (!form.title.trim()) return { error: 'Titel ist erforderlich' };
-    if (!form.date_from) return { error: 'Von-Datum ist erforderlich' };
-    if (!form.industry.trim()) return { error: 'Branche ist erforderlich' };
-    if (!form.contact.trim()) return { error: 'Ansprechpartner ist erforderlich' };
-    if (!form.fte || isNaN(fte) || fte <= 0) return { error: 'Umfang (FTE) muss > 0 sein' };
-    if (!form.topic.trim()) return { error: 'Thema ist erforderlich' };
-    if (!form.roles.trim()) return { error: 'Rolle(n) ist erforderlich' };
-    if (!form.responsibilities.trim()) return { error: 'Verantwortlichkeiten sind erforderlich' };
-
+    if (!form.title.trim()) { setFormError('Titel ist erforderlich'); return null; }
+    if (!form.date_from) { setFormError('Von-Datum ist erforderlich'); return null; }
+    if (!form.industry.trim()) { setFormError('Branche ist erforderlich'); return null; }
+    if (!form.contact.trim()) { setFormError('Ansprechpartner ist erforderlich'); return null; }
+    if (!form.fte || isNaN(fte) || fte <= 0) { setFormError('Umfang (FTE) muss > 0 sein'); return null; }
+    if (!form.topic.trim()) { setFormError('Thema ist erforderlich'); return null; }
+    if (!form.roles.trim()) { setFormError('Rolle(n) ist erforderlich'); return null; }
+    if (!form.responsibilities.trim()) { setFormError('Verantwortlichkeiten sind erforderlich'); return null; }
     return {
-      payload: {
-        title: form.title.trim(),
-        date_from: form.date_from,
-        date_to: form.date_to || null,
-        industry: form.industry.trim(),
-        contact: form.contact.trim(),
-        fte,
-        topic: form.topic.trim(),
-        roles: form.roles.trim(),
-        responsibilities: form.responsibilities.trim(),
-      },
+      title: form.title.trim(),
+      date_from: form.date_from,
+      date_to: form.date_to || null,
+      industry: form.industry.trim(),
+      contact: form.contact.trim(),
+      fte,
+      topic: form.topic.trim(),
+      roles: form.roles.trim(),
+      responsibilities: form.responsibilities.trim(),
     };
   }
 
   async function submit() {
-    const result = buildPayload();
-    if ('error' in result) {
-      setFormError(result.error);
-      return;
-    }
-    setSubmitting(true);
     setFormError('');
+    const payload = buildPayload();
+    if (!payload) return;
+    setSubmitting(true);
     try {
       if (mode === 'create') {
-        const created = await adminCreateProjektreferenz(result.payload);
+        const created = await adminCreateProjektreferenz(payload);
         setRefs((prev) => [created, ...prev]);
       } else if (mode === 'edit' && editingId !== null) {
-        const updated = await adminUpdateProjektreferenz(editingId, result.payload);
+        const updated = await adminUpdateProjektreferenz(editingId, payload);
         setRefs((prev) => prev.map((r) => (r.id === updated.id ? updated : r)));
       }
       closeForm();

--- a/frontend/src/pages/AdminProjektreferenzen.tsx
+++ b/frontend/src/pages/AdminProjektreferenzen.tsx
@@ -1,0 +1,384 @@
+import { useCallback, useEffect, useState } from 'react';
+import { AdminLayout } from '../components/AdminLayout';
+import { Button } from '../components/Button';
+import {
+  adminListProjektreferenzen,
+  adminCreateProjektreferenz,
+  adminUpdateProjektreferenz,
+  adminDeleteProjektreferenz,
+} from '../api/projektreferenzen';
+import type { ProjectReference } from '../types';
+
+const EMPTY_FORM = {
+  title: '',
+  date_from: '',
+  date_to: '',
+  industry: '',
+  contact: '',
+  fte: '',
+  topic: '',
+  roles: '',
+  responsibilities: '',
+};
+
+type FormState = typeof EMPTY_FORM;
+type FormMode = 'none' | 'create' | 'edit';
+
+const inputClass =
+  'w-full px-3 py-2 text-sm rounded-lg border border-border bg-bg-primary focus:outline-none focus:border-text-muted';
+const labelClass = 'block text-sm font-medium mb-1';
+
+function formatDate(iso: string | null): string {
+  if (!iso) return 'aktuell';
+  const [y, m, d] = iso.split('-');
+  return `${d}.${m}.${y}`;
+}
+
+function formatFte(fte: number): string {
+  return fte % 1 === 0 ? `${fte}` : `${fte}`;
+}
+
+function refToForm(ref: ProjectReference): FormState {
+  return {
+    title: ref.title,
+    date_from: ref.date_from,
+    date_to: ref.date_to ?? '',
+    industry: ref.industry,
+    contact: ref.contact,
+    fte: String(ref.fte),
+    topic: ref.topic,
+    roles: ref.roles,
+    responsibilities: ref.responsibilities,
+  };
+}
+
+export function AdminProjektreferenzen() {
+  const [refs, setRefs] = useState<ProjectReference[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [listError, setListError] = useState('');
+
+  const [mode, setMode] = useState<FormMode>('none');
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [form, setForm] = useState<FormState>(EMPTY_FORM);
+  const [formError, setFormError] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  const load = useCallback(() => {
+    setLoading(true);
+    adminListProjektreferenzen()
+      .then(setRefs)
+      .catch((e) => setListError(e instanceof Error ? e.message : 'Fehler beim Laden'))
+      .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  function openCreate() {
+    setForm(EMPTY_FORM);
+    setFormError('');
+    setEditingId(null);
+    setMode('create');
+  }
+
+  function openEdit(ref: ProjectReference) {
+    setForm(refToForm(ref));
+    setFormError('');
+    setEditingId(ref.id);
+    setMode('edit');
+  }
+
+  function closeForm() {
+    setMode('none');
+    setEditingId(null);
+    setForm(EMPTY_FORM);
+    setFormError('');
+  }
+
+  function set(field: keyof FormState, value: string) {
+    setForm((prev) => ({ ...prev, [field]: value }));
+  }
+
+  function buildPayload() {
+    const fte = parseFloat(form.fte);
+    if (!form.title.trim()) return { error: 'Titel ist erforderlich' };
+    if (!form.date_from) return { error: 'Von-Datum ist erforderlich' };
+    if (!form.industry.trim()) return { error: 'Branche ist erforderlich' };
+    if (!form.contact.trim()) return { error: 'Ansprechpartner ist erforderlich' };
+    if (!form.fte || isNaN(fte) || fte <= 0) return { error: 'Umfang (FTE) muss > 0 sein' };
+    if (!form.topic.trim()) return { error: 'Thema ist erforderlich' };
+    if (!form.roles.trim()) return { error: 'Rolle(n) ist erforderlich' };
+    if (!form.responsibilities.trim()) return { error: 'Verantwortlichkeiten sind erforderlich' };
+
+    return {
+      payload: {
+        title: form.title.trim(),
+        date_from: form.date_from,
+        date_to: form.date_to || null,
+        industry: form.industry.trim(),
+        contact: form.contact.trim(),
+        fte,
+        topic: form.topic.trim(),
+        roles: form.roles.trim(),
+        responsibilities: form.responsibilities.trim(),
+      },
+    };
+  }
+
+  async function submit() {
+    const result = buildPayload();
+    if ('error' in result) {
+      setFormError(result.error);
+      return;
+    }
+    setSubmitting(true);
+    setFormError('');
+    try {
+      if (mode === 'create') {
+        const created = await adminCreateProjektreferenz(result.payload);
+        setRefs((prev) => [created, ...prev]);
+      } else if (mode === 'edit' && editingId !== null) {
+        const updated = await adminUpdateProjektreferenz(editingId, result.payload);
+        setRefs((prev) => prev.map((r) => (r.id === updated.id ? updated : r)));
+      }
+      closeForm();
+    } catch (e) {
+      setFormError(e instanceof Error ? e.message : 'Fehler beim Speichern');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function deleteRef(ref: ProjectReference) {
+    if (!confirm(`Projektreferenz "${ref.title}" wirklich löschen?`)) return;
+    try {
+      await adminDeleteProjektreferenz(ref.id);
+      setRefs((prev) => prev.filter((r) => r.id !== ref.id));
+    } catch (e) {
+      setListError(e instanceof Error ? e.message : 'Fehler beim Löschen');
+    }
+  }
+
+  if (loading) {
+    return <AdminLayout><p className="text-text-muted">Lade...</p></AdminLayout>;
+  }
+
+  return (
+    <AdminLayout>
+      {/* ---------- Header ---------- */}
+      <div className="flex items-center justify-between mb-6">
+        <h2 className="text-sm font-medium uppercase tracking-wider text-text-muted">
+          {mode === 'none'
+            ? 'Projektreferenzen'
+            : mode === 'create'
+            ? 'Neue Referenz'
+            : 'Referenz bearbeiten'}
+        </h2>
+        {mode === 'none' ? (
+          <Button variant="primary" onClick={openCreate}>
+            + Neue Referenz
+          </Button>
+        ) : (
+          <button
+            type="button"
+            onClick={closeForm}
+            disabled={submitting}
+            className="text-sm text-text-muted hover:text-text-primary"
+          >
+            Abbrechen
+          </button>
+        )}
+      </div>
+
+      {listError && (
+        <p className="text-red-600 bg-red-50 p-4 rounded mb-4">{listError}</p>
+      )}
+
+      {/* ---------- Formular ---------- */}
+      {mode !== 'none' && (
+        <div className="rounded-lg border border-border bg-bg-secondary p-5 mb-8 space-y-4">
+          <div>
+            <label className={labelClass}>Titel *</label>
+            <input
+              type="text"
+              value={form.title}
+              onChange={(e) => set('title', e.target.value)}
+              maxLength={200}
+              disabled={submitting}
+              className={inputClass}
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className={labelClass}>Zeitraum von *</label>
+              <input
+                type="date"
+                value={form.date_from}
+                onChange={(e) => set('date_from', e.target.value)}
+                disabled={submitting}
+                className={inputClass}
+              />
+            </div>
+            <div>
+              <label className={labelClass}>Zeitraum bis</label>
+              <input
+                type="date"
+                value={form.date_to}
+                onChange={(e) => set('date_to', e.target.value)}
+                disabled={submitting}
+                className={inputClass}
+              />
+              <p className="text-xs text-text-muted mt-1">Leer lassen wenn laufend</p>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className={labelClass}>Branche *</label>
+              <input
+                type="text"
+                value={form.industry}
+                onChange={(e) => set('industry', e.target.value)}
+                maxLength={200}
+                disabled={submitting}
+                className={inputClass}
+              />
+            </div>
+            <div>
+              <label className={labelClass}>Ansprechpartner *</label>
+              <input
+                type="text"
+                value={form.contact}
+                onChange={(e) => set('contact', e.target.value)}
+                maxLength={200}
+                disabled={submitting}
+                className={inputClass}
+              />
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className={labelClass}>Umfang (FTE) *</label>
+              <input
+                type="number"
+                value={form.fte}
+                onChange={(e) => set('fte', e.target.value)}
+                step="0.1"
+                min="0.1"
+                disabled={submitting}
+                className={inputClass}
+              />
+            </div>
+          </div>
+
+          <div>
+            <label className={labelClass}>Thema *</label>
+            <input
+              type="text"
+              value={form.topic}
+              onChange={(e) => set('topic', e.target.value)}
+              disabled={submitting}
+              className={inputClass}
+            />
+          </div>
+
+          <div>
+            <label className={labelClass}>Rolle(n) *</label>
+            <input
+              type="text"
+              value={form.roles}
+              onChange={(e) => set('roles', e.target.value)}
+              disabled={submitting}
+              className={inputClass}
+            />
+          </div>
+
+          <div>
+            <label className={labelClass}>Verantwortlichkeiten *</label>
+            <textarea
+              value={form.responsibilities}
+              onChange={(e) => set('responsibilities', e.target.value)}
+              rows={4}
+              disabled={submitting}
+              placeholder="Eine Verantwortlichkeit pro Zeile"
+              className={inputClass}
+            />
+            <p className="text-xs text-text-muted mt-1">
+              Jede Zeile wird als Aufzählungspunkt angezeigt.
+            </p>
+          </div>
+
+          {formError && <p className="text-red-600 text-sm">{formError}</p>}
+
+          <div className="flex justify-end pt-2">
+            <Button variant="primary" onClick={submit} disabled={submitting}>
+              {submitting ? 'Speichere...' : mode === 'create' ? 'Anlegen' : 'Speichern'}
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {/* ---------- Liste ---------- */}
+      {mode === 'none' && (
+        refs.length === 0 ? (
+          <p className="text-text-muted text-sm">Noch keine Projektreferenzen angelegt.</p>
+        ) : (
+          <div className="space-y-3">
+            {refs.map((ref) => (
+              <div
+                key={ref.id}
+                className="rounded-lg border border-border bg-bg-secondary p-4"
+              >
+                <div className="flex items-start justify-between gap-3 flex-wrap">
+                  <div className="flex-1 min-w-0">
+                    <p className="font-medium truncate">{ref.title}</p>
+                    <p className="text-sm text-text-muted mt-0.5">
+                      {formatDate(ref.date_from)} – {formatDate(ref.date_to)}
+                      {' · '}
+                      {ref.industry}
+                      {' · '}
+                      {formatFte(ref.fte)} FTE
+                    </p>
+                    <p className="text-sm text-text-muted">{ref.topic}</p>
+                  </div>
+                  <div className="flex gap-1 flex-shrink-0">
+                    <button
+                      type="button"
+                      onClick={() => openEdit(ref)}
+                      className="text-xs px-2 py-1 rounded border border-border hover:bg-bg-primary"
+                    >
+                      Bearbeiten
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => deleteRef(ref)}
+                      className="text-xs px-2 py-1 rounded border border-red-600 text-red-600 hover:bg-red-50"
+                    >
+                      Löschen
+                    </button>
+                  </div>
+                </div>
+
+                {/* Verantwortlichkeiten als Aufzählung */}
+                {ref.responsibilities && (
+                  <ul className="mt-3 space-y-0.5 pl-4 list-disc text-sm text-text-muted">
+                    {ref.responsibilities
+                      .split('\n')
+                      .map((line) => line.trim())
+                      .filter((line) => line.length > 0)
+                      .map((line, i) => (
+                        <li key={i}>{line}</li>
+                      ))}
+                  </ul>
+                )}
+              </div>
+            ))}
+          </div>
+        )
+      )}
+    </AdminLayout>
+  );
+}

--- a/frontend/src/pages/AdminProjektreferenzen.tsx
+++ b/frontend/src/pages/AdminProjektreferenzen.tsx
@@ -7,7 +7,7 @@ import {
   adminUpdateProjektreferenz,
   adminDeleteProjektreferenz,
 } from '../api/projektreferenzen';
-import type { ProjectReference } from '../types';
+import type { ProjectReference, ProjectReferenceInput } from '../types';
 
 const EMPTY_FORM = {
   title: '',

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -245,3 +245,32 @@ export interface NotificationListResponse {
   limit: number;
   offset: number;
 }
+
+// ---------- Projektreferenzen ----------
+
+export interface ProjectReference {
+  id: number;
+  title: string;
+  date_from: string;
+  date_to: string | null;
+  industry: string;
+  contact: string;
+  fte: number;
+  topic: string;
+  roles: string;
+  responsibilities: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ProjectReferenceInput {
+  title: string;
+  date_from: string;
+  date_to: string | null;
+  industry: string;
+  contact: string;
+  fte: number;
+  topic: string;
+  roles: string;
+  responsibilities: string;
+}


### PR DESCRIPTION
## Summary
- Neue Admin-Seite unter `/admin/projektreferenzen` für CRUD-Verwaltung von Projektreferenzen
- Felder: Titel, Zeitraum (von/bis), Branche, Ansprechpartner, Umfang (FTE), Thema, Rolle(n), Verantwortlichkeiten
- Verantwortlichkeiten werden zeilenweise als Aufzählungsliste angezeigt
- Backend: FastAPI-Router `/projektreferenzen/` (Admin-only), Alembic-Migration

## Test plan
- [ ] CI grün (Backend-Tests + E2E)
- [ ] Neue Referenz anlegen, alle Felder prüfen
- [ ] Bearbeiten einer bestehenden Referenz
- [ ] Löschen mit Bestätigungsdialog
- [ ] Nav-Tab im Admin-Dashboard sichtbar
- [ ] Nicht-Admin-User wird auf `/` weitergeleitet

🤖 Generated with [Claude Code](https://claude.com/claude-code)