### PR TITLE
feat: CV-Seite mit Navbar-Eintrag (Admin only)

### DIFF
--- a/backend/routers/cv.py
+++ b/backend/routers/cv.py
@@ -314,7 +314,7 @@ def list_certificates(
 ):
     return (
         db.query(models.CVCertificate)
-        .order_by(models.CVCertificate.sort_order, models.CVCertificate.id)
+        .order_by(models.CVCertificate.sort_order, models.CVCertificate.jahr.desc(), models.CVCertificate.id.desc())
         .all()
     )
 


### PR DESCRIPTION
## Summary
- Neue `/cv`-Seite (Admin only) mit 5 Tabs: Persönliches, Berufliche Tätigkeiten, Fähigkeiten & Zertifikate, Ausbildung & Studium, Projektreferenzen
- CV-Link in Navbar (Desktop + Mobile), nur sichtbar für `is_admin`
- Projektreferenzen aus Admin-Bereich entfernt — Daten und API bleiben unverändert
- 5 neue DB-Tabellen via Alembic-Migration `d4e5f6a7b8c9`
- Neuer Backend-Router `/cv` mit CRUD für alle Sektionen (alle Endpoints `require_admin`)
- Alle Listen sortiert: neueste Einträge zuerst (nach `date_from` bzw. `jahr`)

## Test plan
- [ ] CI grün
- [ ] Navbar zeigt CV-Link nur für Admin
- [ ] Persönliches: Speichern (Upsert)
- [ ] Berufliche Tätigkeiten: CRUD, neueste oben
- [ ] Fähigkeiten: Sprachen und Zertifikate CRUD, Zertifikate nach Jahr absteigend
- [ ] Ausbildung: CRUD, neueste oben
- [ ] Projektreferenzen: bestehende Daten sichtbar, CRUD funktioniert
- [ ] `/admin/projektreferenzen` gibt 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)