### PR TITLE
feat: CV Übersicht-Tab mit PDF-Export

### DIFF
--- a/backend/routers/cv.py
+++ b/backend/routers/cv.py
@@ -314,7 +314,7 @@ def list_certificates(
 ):
     return (
         db.query(models.CVCertificate)
-        .order_by(models.CVCertificate.sort_order, models.CVCertificate.id)
+        .order_by(models.CVCertificate.jahr.desc(), models.CVCertificate.id.desc())
         .all()
     )
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -43,3 +43,22 @@
   --color-border: #2E2E2E;
   --color-border-light: #252525;
 }
+
+@media print {
+  @page { margin: 1.5cm; }
+
+  body { visibility: hidden; }
+
+  #cv-overview-print {
+    visibility: visible;
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    color: #000;
+  }
+
+  #cv-projects-break {
+    break-before: page;
+  }
+}

--- a/frontend/src/pages/CV.tsx
+++ b/frontend/src/pages/CV.tsx
@@ -202,13 +202,12 @@ function ExperienceTab() {
         sort_order: 0,
       };
       if (mode === 'create') {
-        const created = await createCVExperience(payload);
-        setItems((prev) => [created, ...prev]);
+        await createCVExperience(payload);
       } else if (mode === 'edit' && editingId !== null) {
-        const updated = await updateCVExperience(editingId, payload);
-        setItems((prev) => prev.map((i) => (i.id === updated.id ? updated : i)));
+        await updateCVExperience(editingId, payload);
       }
       closeForm();
+      load();
     } catch (e) {
       setFormError(e instanceof Error ? e.message : 'Fehler beim Speichern');
     } finally {
@@ -395,15 +394,14 @@ function SkillsTab() {
     try {
       const payload = { name: certForm.name.trim(), jahr, sort_order: 0 };
       if (certMode === 'create') {
-        const created = await createCVCertificate(payload);
-        setCerts((prev) => [...prev, created]);
+        await createCVCertificate(payload);
       } else if (certMode === 'edit' && certEditId !== null) {
-        const updated = await updateCVCertificate(certEditId, payload);
-        setCerts((prev) => prev.map((c) => (c.id === updated.id ? updated : c)));
+        await updateCVCertificate(certEditId, payload);
       }
       setCertMode('none');
       setCertEditId(null);
       setCertForm({ name: '', jahr: String(new Date().getFullYear()) });
+      load();
     } catch (e) {
       setCertError(e instanceof Error ? e.message : 'Fehler');
     } finally {
@@ -593,13 +591,12 @@ function EducationTab() {
     try {
       const payload = { date_from: form.date_from, date_to: form.date_to || null, beschreibung: form.beschreibung.trim(), sort_order: 0 };
       if (mode === 'create') {
-        const created = await createCVEducation(payload);
-        setItems((prev) => [created, ...prev]);
+        await createCVEducation(payload);
       } else if (mode === 'edit' && editingId !== null) {
-        const updated = await updateCVEducation(editingId, payload);
-        setItems((prev) => prev.map((i) => (i.id === updated.id ? updated : i)));
+        await updateCVEducation(editingId, payload);
       }
       closeForm();
+      load();
     } catch (e) {
       setFormError(e instanceof Error ? e.message : 'Fehler beim Speichern');
     } finally {
@@ -742,13 +739,12 @@ function ProjectsTab() {
     setSubmitting(true);
     try {
       if (mode === 'create') {
-        const created = await adminCreateProjektreferenz(payload);
-        setRefs((prev) => [created, ...prev]);
+        await adminCreateProjektreferenz(payload);
       } else if (mode === 'edit' && editingId !== null) {
-        const updated = await adminUpdateProjektreferenz(editingId, payload);
-        setRefs((prev) => prev.map((r) => (r.id === updated.id ? updated : r)));
+        await adminUpdateProjektreferenz(editingId, payload);
       }
       closeForm();
+      load();
     } catch (e) {
       setFormError(e instanceof Error ? e.message : 'Fehler beim Speichern');
     } finally {

--- a/frontend/src/pages/CV.tsx
+++ b/frontend/src/pages/CV.tsx
@@ -30,6 +30,7 @@ import {
   adminDeleteProjektreferenz,
 } from '../api/projektreferenzen';
 import type {
+  CVProfile,
   CVExperience,
   CVLanguage,
   CVCertificate,
@@ -38,7 +39,7 @@ import type {
   ProjectReferenceInput,
 } from '../types';
 
-type CVTab = 'personal' | 'experience' | 'skills' | 'education' | 'projects';
+type CVTab = 'personal' | 'experience' | 'skills' | 'education' | 'projects' | 'overview';
 
 const TAB_LABELS: Record<CVTab, string> = {
   personal: 'Persönliches',
@@ -46,6 +47,7 @@ const TAB_LABELS: Record<CVTab, string> = {
   skills: 'Fähigkeiten & Zertifikate',
   education: 'Ausbildung & Studium',
   projects: 'Projektreferenzen',
+  overview: 'Übersicht & Export',
 };
 
 const inputClass =
@@ -872,6 +874,185 @@ function ProjectsTab() {
   );
 }
 
+// ────────────────────── Übersicht & Export ──────────────────────
+
+function formatBirthdate(iso: string): string {
+  const [y, m, d] = iso.split('-');
+  return `${d}.${m}.${y}`;
+}
+
+function OverviewTab() {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [profile, setProfile] = useState<CVProfile | null>(null);
+  const [experiences, setExperiences] = useState<CVExperience[]>([]);
+  const [languages, setLanguages] = useState<CVLanguage[]>([]);
+  const [certs, setCerts] = useState<CVCertificate[]>([]);
+  const [educations, setEducations] = useState<CVEducation[]>([]);
+  const [projects, setProjects] = useState<ProjectReference[]>([]);
+
+  useEffect(() => {
+    Promise.all([
+      getCVProfile(),
+      listCVExperiences(),
+      listCVLanguages(),
+      listCVCertificates(),
+      listCVEducations(),
+      adminListProjektreferenzen(),
+    ])
+      .then(([p, exps, langs, cs, edus, projs]) => {
+        setProfile(p);
+        setExperiences(exps);
+        setLanguages(langs);
+        setCerts(cs);
+        setEducations(edus);
+        setProjects(projs);
+      })
+      .catch((e) => setError(e instanceof Error ? e.message : 'Fehler beim Laden'))
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) return <p className="text-text-muted">Lade...</p>;
+  if (error) return <p className="text-red-600 bg-red-50 p-4 rounded">{error}</p>;
+
+  const hasPersonal = profile && (profile.vorname || profile.nachname || profile.geburtsdatum);
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-6 print:hidden">
+        <h2 className="text-sm font-medium uppercase tracking-wider text-text-muted">Übersicht</h2>
+        <Button variant="primary" onClick={() => window.print()}>Als PDF exportieren</Button>
+      </div>
+
+      <div id="cv-overview-print">
+        {hasPersonal && (
+          <div className="mb-8">
+            {(profile.vorname || profile.nachname) && (
+              <h1 className="text-2xl font-semibold">
+                {[profile.vorname, profile.nachname].filter(Boolean).join(' ')}
+              </h1>
+            )}
+            {profile.geburtsdatum && (
+              <p className="text-sm text-text-muted mt-1">* {formatBirthdate(profile.geburtsdatum)}</p>
+            )}
+          </div>
+        )}
+
+        {experiences.length > 0 && (
+          <section className="mb-8">
+            <h2 className="text-xs font-semibold uppercase tracking-wider text-text-muted border-b border-border pb-1 mb-4">
+              Berufliche Tätigkeiten
+            </h2>
+            <div className="space-y-4">
+              {experiences.map((exp) => (
+                <div key={exp.id}>
+                  <div className="flex items-baseline justify-between gap-4 flex-wrap">
+                    <span className="font-medium">{exp.rolle}</span>
+                    <span className="text-sm text-text-muted whitespace-nowrap">
+                      {formatDate(exp.date_from)} – {formatDate(exp.date_to)}
+                    </span>
+                  </div>
+                  {exp.beschreibung && (
+                    <ul className="mt-1 pl-4 list-disc text-sm text-text-muted space-y-0.5">
+                      {exp.beschreibung.split('\n').map((l) => l.trim()).filter((l) => l).map((l, i) => (
+                        <li key={i}>{l}</li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
+              ))}
+            </div>
+          </section>
+        )}
+
+        {(languages.length > 0 || certs.length > 0) && (
+          <section className="mb-8 grid grid-cols-2 gap-8">
+            {languages.length > 0 && (
+              <div>
+                <h2 className="text-xs font-semibold uppercase tracking-wider text-text-muted border-b border-border pb-1 mb-4">
+                  Sprachen
+                </h2>
+                <div className="space-y-1">
+                  {languages.map((lang) => (
+                    <div key={lang.id} className="flex justify-between text-sm">
+                      <span>{lang.sprache}</span>
+                      <span className="text-text-muted">{lang.niveau}</span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+            {certs.length > 0 && (
+              <div>
+                <h2 className="text-xs font-semibold uppercase tracking-wider text-text-muted border-b border-border pb-1 mb-4">
+                  Zertifikate
+                </h2>
+                <div className="space-y-1">
+                  {certs.map((cert) => (
+                    <div key={cert.id} className="flex justify-between text-sm">
+                      <span>{cert.name}</span>
+                      <span className="text-text-muted">{cert.jahr}</span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+          </section>
+        )}
+
+        {educations.length > 0 && (
+          <section className="mb-8">
+            <h2 className="text-xs font-semibold uppercase tracking-wider text-text-muted border-b border-border pb-1 mb-4">
+              Ausbildung & Studium
+            </h2>
+            <div className="space-y-3">
+              {educations.map((edu) => (
+                <div key={edu.id} className="flex gap-6 text-sm">
+                  <span className="text-text-muted whitespace-nowrap">
+                    {formatDate(edu.date_from)} – {formatDate(edu.date_to)}
+                  </span>
+                  <span className="whitespace-pre-wrap">{edu.beschreibung}</span>
+                </div>
+              ))}
+            </div>
+          </section>
+        )}
+
+        {projects.length > 0 && (
+          <section id="cv-projects-break">
+            <h2 className="text-xs font-semibold uppercase tracking-wider text-text-muted border-b border-border pb-1 mb-4">
+              Projektreferenzen
+            </h2>
+            <div className="space-y-6">
+              {projects.map((ref) => (
+                <div key={ref.id}>
+                  <div className="flex items-baseline justify-between gap-4 flex-wrap">
+                    <span className="font-medium">{ref.title}</span>
+                    <span className="text-sm text-text-muted whitespace-nowrap">
+                      {formatDate(ref.date_from)} – {formatDate(ref.date_to)}
+                    </span>
+                  </div>
+                  <p className="text-sm text-text-muted mt-0.5">
+                    {ref.industry} · {ref.fte} FTE · {ref.roles}
+                  </p>
+                  <p className="text-sm mt-0.5">{ref.topic}</p>
+                  {ref.responsibilities && (
+                    <ul className="mt-1 pl-4 list-disc text-sm text-text-muted space-y-0.5">
+                      {ref.responsibilities.split('\n').map((l) => l.trim()).filter((l) => l).map((l, i) => (
+                        <li key={i}>{l}</li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
+              ))}
+            </div>
+          </section>
+        )}
+      </div>
+    </div>
+  );
+}
+
 // ────────────────────── CV (Hauptseite) ──────────────────────
 
 export function CV() {
@@ -918,6 +1099,7 @@ export function CV() {
         {activeTab === 'skills' && <SkillsTab />}
         {activeTab === 'education' && <EducationTab />}
         {activeTab === 'projects' && <ProjectsTab />}
+        {activeTab === 'overview' && <OverviewTab />}
       </div>
     </Layout>
   );


### PR DESCRIPTION
## Summary

- Neuer Tab **Übersicht & Export** am Ende der CV-Tab-Leiste
- Aggregiert alle Daten aus allen anderen Tabs in einer kompakten Leseansicht (kein Edit möglich)
- **PDF-Export** per Button → `window.print()` → Browser-Druckdialog → "Als PDF speichern"
- Print-CSS: Navbar/UI werden ausgeblendet, nur `#cv-overview-print` bleibt sichtbar (`visibility` Trick)
- Projektreferenzen starten auf neuer Seite (`break-before: page`)
- Kein neues npm-Dependency

## Test plan

- [ ] Tab "Übersicht & Export" erscheint und lädt alle Sektionen korrekt
- [ ] Leere Sektionen werden nicht gerendert (keine leeren Boxen)
- [ ] "Als PDF exportieren" öffnet den Browser-Druckdialog
- [ ] Im Print-Preview: Nur CV-Inhalt sichtbar, kein Navbar/Tabs
- [ ] Projektreferenzen beginnen auf einer neuen Seite

🤖 Generated with [Claude Code](https://claude.com/claude-code)