### PR TITLE
feat: Wand-Dashboard v1 (/wand)

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -40,6 +40,11 @@ def create_token(data: dict):
     data.update({"exp": expire})
     return jwt.encode(data, SECRET_KEY, algorithm=ALGORITHM)
 
+def create_token_expires_in(data: dict, expires_in: timedelta):
+    expire = datetime.now(timezone.utc) + expires_in
+    data.update({"exp": expire})
+    return jwt.encode(data, SECRET_KEY, algorithm=ALGORITHM)
+
 def get_current_user(token: str = Depends(oauth2_scheme), db: Session = Depends(get_db)):
     try:
         payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -186,6 +186,27 @@ def request_password_reset(
     return generic_response
 
 
+class KioskTokenRequest(BaseModel):
+    user_id: int
+
+@router.post("/kiosk-token")
+def create_kiosk_token(
+    data: KioskTokenRequest,
+    db: Session = Depends(get_db),
+    _admin: models.User = Depends(auth.require_admin),
+):
+    user = db.query(models.User).filter(models.User.id == data.user_id).first()
+    if not user:
+        raise HTTPException(status_code=404, detail="Benutzer nicht gefunden")
+    if not user.is_household:
+        raise HTTPException(status_code=400, detail="Benutzer ist kein Haushaltsmitglied")
+    token = auth.create_token_expires_in(
+        {"sub": user.email},
+        timedelta(days=365),
+    )
+    return {"access_token": token, "token_type": "bearer", "expires_in_days": 365}
+
+
 @router.post("/reset-password")
 @limiter.limit("10/hour")
 def reset_password(

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -361,3 +361,43 @@ class TestPasswordReset:
             "confirm_password": "DifferentPass789!",
         })
         assert response.status_code == 400
+
+
+# ========== Integration: /auth/kiosk-token ==========
+
+class TestKioskToken:
+    def test_admin_can_create_kiosk_token_for_household_user(self, client, admin_headers, household_user):
+        response = client.post("/auth/kiosk-token", json={"user_id": household_user.id}, headers=admin_headers)
+        assert response.status_code == 200
+        body = response.json()
+        assert "access_token" in body
+        assert body["token_type"] == "bearer"
+        assert body["expires_in_days"] == 365
+
+    def test_kiosk_token_is_valid_jwt_with_household_sub(self, client, admin_headers, household_user):
+        import os
+        from jose import jwt as jose_jwt
+        response = client.post("/auth/kiosk-token", json={"user_id": household_user.id}, headers=admin_headers)
+        token = response.json()["access_token"]
+        decoded = jose_jwt.decode(token, os.environ["JWT_SECRET"], algorithms=["HS256"])
+        assert decoded["sub"] == household_user.email
+
+    def test_kiosk_token_grants_shopping_access(self, client, admin_headers, household_user):
+        kiosk_token = client.post(
+            "/auth/kiosk-token", json={"user_id": household_user.id}, headers=admin_headers
+        ).json()["access_token"]
+        kiosk_headers = {"Authorization": f"Bearer {kiosk_token}"}
+        response = client.get("/shopping/items", headers=kiosk_headers)
+        assert response.status_code == 200
+
+    def test_non_admin_cannot_create_kiosk_token(self, client, household_headers, household_user):
+        response = client.post("/auth/kiosk-token", json={"user_id": household_user.id}, headers=household_headers)
+        assert response.status_code == 403
+
+    def test_kiosk_token_rejected_for_non_household_user(self, client, admin_headers, test_user):
+        response = client.post("/auth/kiosk-token", json={"user_id": test_user.id}, headers=admin_headers)
+        assert response.status_code == 400
+
+    def test_kiosk_token_rejected_for_unknown_user(self, client, admin_headers):
+        response = client.post("/auth/kiosk-token", json={"user_id": 99999}, headers=admin_headers)
+        assert response.status_code == 404

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -25,6 +25,7 @@ import { Impostor } from './pages/Impostor';
 import { AdminImpostor } from './pages/AdminImpostor';
 import { CV } from './pages/CV';
 import { Feuerrot } from './pages/Feuerrot';
+import { WandDashboard } from './pages/WandDashboard';
 
 function App() {
   return (
@@ -58,6 +59,7 @@ function App() {
         <Route path="/diary" element={<Diary />} />
         <Route path="/diary/neu" element={<DiaryNew />} />
         <Route path="/diary/:id/bearbeiten" element={<DiaryEdit />} />
+        <Route path="/wand" element={<WandDashboard />} />
         <Route path="*" element={<NotFound />} />
       </Routes>
     </BrowserRouter>

--- a/frontend/src/pages/WandDashboard.tsx
+++ b/frontend/src/pages/WandDashboard.tsx
@@ -1,0 +1,111 @@
+import { useEffect, useState, useCallback } from 'react';
+import { getToken } from '../lib/api';
+import type { ShoppingItem } from '../types';
+
+const API_URL = import.meta.env.VITE_API_URL;
+const POLL_INTERVAL_MS = 60_000;
+
+export function WandDashboard() {
+  const [items, setItems] = useState<ShoppingItem[]>([]);
+  const [now, setNow] = useState(new Date());
+  const [authError, setAuthError] = useState(false);
+
+  // Kiosk-Token aus ?token= einmalig in localStorage übernehmen
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const tokenParam = params.get('token');
+    if (tokenParam) {
+      localStorage.setItem('token', tokenParam);
+      window.history.replaceState({}, '', window.location.pathname);
+    }
+  }, []);
+
+  const fetchItems = useCallback(async () => {
+    const token = getToken();
+    if (!token) {
+      setAuthError(true);
+      return;
+    }
+    try {
+      const res = await fetch(`${API_URL}/shopping/items`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (res.status === 401) {
+        setAuthError(true);
+        return;
+      }
+      if (!res.ok) return;
+      setItems(await res.json());
+      setAuthError(false);
+    } catch {
+      // Netzwerkfehler: bestehende Daten behalten
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchItems();
+    const id = setInterval(fetchItems, POLL_INTERVAL_MS);
+    return () => clearInterval(id);
+  }, [fetchItems]);
+
+  useEffect(() => {
+    const id = setInterval(() => setNow(new Date()), 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  const timeStr = now.toLocaleTimeString('de-DE', { hour: '2-digit', minute: '2-digit' });
+  const dateStr = now.toLocaleDateString('de-DE', {
+    weekday: 'long',
+    day: 'numeric',
+    month: 'long',
+  });
+
+  if (authError) {
+    return (
+      <div className="w-screen h-screen bg-bg-secondary flex items-center justify-center">
+        <p className="text-text-muted text-2xl">
+          Kein Zugriff — Kiosk-Token fehlt oder abgelaufen.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-screen h-screen bg-bg-secondary flex overflow-hidden">
+
+      {/* Linke Spalte: Uhr + Datum */}
+      <div className="w-96 shrink-0 flex flex-col items-center justify-center border-r border-border px-8 gap-3">
+        <p className="text-[9rem] font-light leading-none tabular-nums text-text-primary">
+          {timeStr}
+        </p>
+        <p className="text-xl text-text-muted text-center capitalize">{dateStr}</p>
+      </div>
+
+      {/* Rechte Spalte: Einkaufsliste */}
+      <div className="flex-1 flex flex-col p-10 min-h-0">
+        <h2 className="text-xs uppercase tracking-widest text-text-muted font-medium mb-6">
+          Einkaufsliste
+        </h2>
+
+        {items.length === 0 ? (
+          <p className="text-text-hint text-2xl mt-8">Liste ist leer</p>
+        ) : (
+          <ul className="flex-1 overflow-y-auto divide-y divide-border">
+            {items.map(item => (
+              <li key={item.id} className="py-5 flex items-baseline gap-4">
+                <span className="text-text-muted text-xl w-20 shrink-0 text-right">
+                  {item.quantity}
+                </span>
+                <span className="text-3xl font-medium text-text-primary">{item.name}</span>
+                {item.description && (
+                  <span className="text-text-muted text-xl">— {item.description}</span>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- **`POST /auth/kiosk-token`** (Admin-only): stellt einen 365-Tage-JWT für einen bestimmten Household-User aus — für das Kiosk-Gerät, ohne die normale 8h-JWT-Lifetime anzufassen
- **`/wand`-Route**: Kiosk-Dashboard für 1920×1200 Querformat (Samsung Galaxy Tab A8 / Fully Kiosk), kein Navbar/Footer; linke Spalte: Uhr + Datum, rechte Spalte: Einkaufsliste read-only mit 60s-Polling
- Token-Init via `?token=<kiosk-token>` URL-Param — einmalig aufrufen, danach in localStorage, URL wird bereinigt
- Direktes `fetch()` statt `api()`-Helper im Dashboard (verhindert 401→`/login`-Redirect im Kiosk-Modus)

## Inbetriebnahme nach Merge

1. Pi-Deploy: `git pull && docker compose build backend frontend && docker compose up -d`
2. Kiosk-Token einmalig generieren (als Admin eingeloggt):
   ```
   POST /auth/kiosk-token  {"user_id": <household-user-id>}
   ```
3. Fully Kiosk Start-URL setzen: `https://markus-schwarz.cc/wand?token=<token>`

## Test plan

- [ ] Backend-Tests grün (`TestKioskToken` — 6 Tests)
- [ ] E2E-Tests grün
- [ ] TypeScript-Check grün (lokal verifiziert)

🤖 Generated with [Claude Code](https://claude.com/claude-code)