### PR TITLE
fix: CORS-Header für statische Assets (Android WebView)

### DIFF
--- a/frontend/nginx.conf.template
+++ b/frontend/nginx.conf.template
@@ -24,8 +24,11 @@ server {
     }
 
     # Statische Assets länger cachen
+    # Access-Control-Allow-Origin: Android WebView 148+ behandelt <script type="module" crossorigin>
+    # als CORS-Request und dropped den Response ohne diesen Header (Chrome ignoriert das bei Same-Origin)
     location ~* \.(js|css|woff2?|ttf|eot|svg|png|jpg|jpeg|gif|webp|ico)$ {
         expires 30d;
         add_header Cache-Control "public, immutable";
+        add_header Access-Control-Allow-Origin "*";
     }
 }


### PR DESCRIPTION
Android WebView 148+ behandelt `<script type="module" crossorigin>` als CORS-Request und verwirft den Response, wenn `Access-Control-Allow-Origin` fehlt. Dadurch lädt das Wand-Dashboard im Fully Kiosk Browser die JS-Module nicht.

## Änderung
- `frontend/nginx.conf.template`: `add_header Access-Control-Allow-Origin "*"` im `location`-Block für statische Assets (js/css/woff/ttf/svg/png/…).

Same-Origin-Requests in Desktop-Chrome bleiben unberührt. Diese Änderung war bereits auf Prod aktiv (manueller Deploy), wird hiermit nur sauber versioniert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)