### PR TITLE
feat: Einkaufslisten-Digest-Mail an Haushalt alle 15 Min

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,3 +21,9 @@ FROM_EMAIL=noreply@yourdomain.com
 # ==================== Frontend ====================
 # URL über die das Frontend erreichbar ist (für Email-Links)
 FRONTEND_URL=https://yourdomain.com
+
+# ==================== Einkaufslisten-Digest ====================
+# Intervall (in Sekunden), in dem das Backend auf neue Einkaufslisten-Artikel
+# prüft und ggf. eine Sammel-Mail an household/admin verschickt. Optional,
+# Default 900 (15 Minuten).
+# SHOPPING_DIGEST_INTERVAL_SECONDS=900

--- a/backend/email_service.py
+++ b/backend/email_service.py
@@ -1,5 +1,6 @@
 import resend
 import os
+import html
 
 resend.api_key = os.getenv("RESEND_API_KEY")
 FROM_EMAIL = os.getenv("FROM_EMAIL", "noreply@markus-schwarz.cc")
@@ -67,6 +68,58 @@ def send_password_reset_email(to_email: str, name: str, token: str):
             <p style="color: #999; font-size: 12px; margin-top: 32px;">
                 Falls du diese Anfrage nicht gestellt hast, kannst du diese Email ignorieren. Dein Passwort bleibt unverändert.
             </p>
+        </div>
+        """
+    })
+
+def _render_shopping_items(items: list[dict]) -> str:
+    """Rendert eine Artikel-Liste als HTML-<ul>. User-Input wird escaped."""
+    if not items:
+        return '<p style="color: #999; font-size: 14px; margin: 0;">Keine Artikel.</p>'
+    rows = ""
+    for it in items:
+        name = html.escape(it["name"])
+        quantity = html.escape(it["quantity"])
+        desc = it.get("description")
+        desc_html = (
+            f' <span style="color: #999;">– {html.escape(desc)}</span>' if desc else ""
+        )
+        rows += (
+            '<li style="padding: 8px 0; border-bottom: 1px solid #eee; font-size: 14px; color: #333;">'
+            f'<strong>{name}</strong> '
+            f'<span style="color: #666;">({quantity})</span>'
+            f'{desc_html}'
+            '</li>'
+        )
+    return f'<ul style="list-style: none; padding: 0; margin: 0;">{rows}</ul>'
+
+def send_shopping_list_digest(to_email: str, name: str, new_items: list[dict], all_items: list[dict]):
+    """
+    Sammel-Mail über neu hinzugefügte Einkaufslisten-Artikel.
+    new_items / all_items sind Listen von {name, quantity, description}-Dicts.
+    """
+    shopping_url = f"{FRONTEND_URL}/einkaufsliste"
+    count = len(new_items)
+    intro = (
+        f"{count} {'neuer Artikel wurde' if count == 1 else 'neue Artikel wurden'} "
+        "zur Einkaufsliste hinzugefügt:"
+    )
+    resend.Emails.send({
+        "from": FROM_EMAIL,
+        "to": to_email,
+        "subject": f"Neue Artikel auf der Einkaufsliste ({count})",
+        "html": f"""
+        <div style="font-family: sans-serif; max-width: 600px; margin: 0 auto; padding: 40px 20px;">
+            <h1 style="font-size: 24px; font-weight: 500; margin-bottom: 16px;">Hallo {html.escape(name)}!</h1>
+            <p style="color: #666; margin-bottom: 24px;">{intro}</p>
+            <h2 style="font-size: 16px; font-weight: 500; margin: 0 0 8px;">Neu</h2>
+            {_render_shopping_items(new_items)}
+            <h2 style="font-size: 16px; font-weight: 500; margin: 32px 0 8px;">Aktuelle Einkaufsliste</h2>
+            {_render_shopping_items(all_items)}
+            <a href="{shopping_url}"
+               style="display: inline-block; margin-top: 32px; background: #0D0D0D; color: white; padding: 12px 24px; border-radius: 8px; text-decoration: none; font-size: 14px;">
+                Zur Einkaufsliste
+            </a>
         </div>
         """
     })

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,3 +1,5 @@
+from contextlib import asynccontextmanager
+import asyncio
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
@@ -7,6 +9,7 @@ from slowapi.middleware import SlowAPIMiddleware
 from database import Base, engine
 import models
 from routers import auth, shopping, admin, recipes, recipe_comments, tags, seasonal, settings, impostor, diary, notifications, projektreferenzen, cv
+from scheduler import shopping_digest_loop
 from rate_limit import limiter
 import os
 import logging
@@ -15,7 +18,23 @@ logger = logging.getLogger("uvicorn")
 
 os.makedirs(os.getenv("UPLOAD_DIR", "/app/uploads"), exist_ok=True)
 
-app = FastAPI(title="Markus Homepage API")
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    # Background-Loop nicht im Test-Stack starten (kein echter Mailversand).
+    task = None
+    if os.getenv("ENVIRONMENT") != "test":
+        task = asyncio.create_task(shopping_digest_loop())
+    yield
+    if task:
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+
+app = FastAPI(title="Markus Homepage API", lifespan=lifespan)
 app.state.limiter = limiter
 app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 app.add_middleware(SlowAPIMiddleware)

--- a/backend/scheduler.py
+++ b/backend/scheduler.py
@@ -1,0 +1,42 @@
+"""
+In-Prozess-Scheduler für den Einkaufslisten-Digest.
+
+Startet als asyncio-Task in der FastAPI-lifespan (siehe main.py). Der eigentliche
+Check läuft synchron (SQLAlchemy + Resend-HTTP) und wird deshalb über
+asyncio.to_thread ausgelagert, damit der Event-Loop nicht blockiert.
+"""
+import asyncio
+import logging
+import os
+
+from database import SessionLocal
+from shopping_digest import run_shopping_digest
+
+logger = logging.getLogger("uvicorn")
+
+INTERVAL_SECONDS = int(os.getenv("SHOPPING_DIGEST_INTERVAL_SECONDS", "900"))
+
+
+def _run_once():
+    db = SessionLocal()
+    try:
+        run_shopping_digest(db)
+    except Exception:
+        db.rollback()
+        logger.exception("Einkaufslisten-Digest: Tick fehlgeschlagen")
+    finally:
+        db.close()
+
+
+async def shopping_digest_loop():
+    logger.info(
+        "Einkaufslisten-Digest-Loop gestartet (Intervall: %ds)", INTERVAL_SECONDS
+    )
+    while True:
+        await asyncio.sleep(INTERVAL_SECONDS)
+        try:
+            await asyncio.to_thread(_run_once)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("Einkaufslisten-Digest: Loop-Fehler")

--- a/backend/shopping_digest.py
+++ b/backend/shopping_digest.py
@@ -1,0 +1,121 @@
+"""
+Einkaufslisten-Digest: periodischer Check auf neue Artikel und Sammel-Mail.
+
+Wird vom In-Prozess-Scheduler (scheduler.py) alle SHOPPING_DIGEST_INTERVAL_SECONDS
+aufgerufen. Der State (bis wohin bereits benachrichtigt wurde) liegt als
+Highwater-Mark im site_settings-Key WATERMARK_KEY — bewusst NICHT in den
+ALLOWED_KEYS der Settings-API, damit der Wert nicht von außen les-/schreibbar ist.
+"""
+import logging
+from datetime import datetime
+
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+import email_service
+import models
+
+logger = logging.getLogger("uvicorn")
+
+WATERMARK_KEY = "shopping_notify_watermark"
+# Sentinel für "leere Liste beim ersten Lauf" — jeder künftige Artikel ist neuer.
+_EPOCH = datetime(1970, 1, 1)
+
+
+def _get_watermark(db: Session):
+    setting = (
+        db.query(models.SiteSetting)
+        .filter(models.SiteSetting.key == WATERMARK_KEY)
+        .first()
+    )
+    if setting is None or not setting.value:
+        return None
+    try:
+        return datetime.fromisoformat(setting.value)
+    except ValueError:
+        return None
+
+
+def _set_watermark(db: Session, value: datetime):
+    setting = (
+        db.query(models.SiteSetting)
+        .filter(models.SiteSetting.key == WATERMARK_KEY)
+        .first()
+    )
+    if setting:
+        setting.value = value.isoformat()
+    else:
+        db.add(models.SiteSetting(key=WATERMARK_KEY, value=value.isoformat()))
+
+
+def _item_dict(item: models.ShoppingItem) -> dict:
+    return {
+        "name": item.name,
+        "quantity": item.quantity,
+        "description": item.description,
+    }
+
+
+def run_shopping_digest(db: Session) -> bool:
+    """
+    Prüft auf neue Einkaufslisten-Artikel seit dem letzten Watermark und schickt
+    bei Bedarf eine Sammel-Mail an alle household-/admin-User.
+
+    Returns True, wenn eine Mail-Runde verschickt wurde, sonst False.
+    """
+    watermark = _get_watermark(db)
+
+    # Erster Lauf: Baseline auf den neuesten Bestands-Artikel setzen, damit der
+    # vorhandene Listen-Inhalt NICHT als "neu" verschickt wird.
+    if watermark is None:
+        newest = db.query(func.max(models.ShoppingItem.added_at)).scalar()
+        _set_watermark(db, newest or _EPOCH)
+        db.commit()
+        return False
+
+    new_items = (
+        db.query(models.ShoppingItem)
+        .filter(models.ShoppingItem.added_at > watermark)
+        .order_by(models.ShoppingItem.added_at.asc())
+        .all()
+    )
+    if not new_items:
+        return False
+
+    all_items = (
+        db.query(models.ShoppingItem)
+        .order_by(models.ShoppingItem.added_at.desc())
+        .all()
+    )
+    recipients = (
+        db.query(models.User)
+        .filter(models.User.role.in_(["household", "admin"]))
+        .all()
+    )
+
+    new_payload = [_item_dict(i) for i in new_items]
+    all_payload = [_item_dict(i) for i in all_items]
+
+    for user in recipients:
+        if not user.email:
+            continue
+        try:
+            email_service.send_shopping_list_digest(
+                user.email, user.name, new_payload, all_payload
+            )
+        except Exception:
+            logger.exception(
+                "Einkaufslisten-Digest: Versand an %s fehlgeschlagen", user.email
+            )
+
+    # Watermark auf das neueste gerade gemeldete Item fortschreiben — DB-Wert
+    # gegen DB-Wert, damit keine Python/Postgres-Zeitzonen-Mischung entsteht.
+    _set_watermark(db, max(i.added_at for i in new_items))
+    db.commit()
+
+    logger.info(
+        "Einkaufslisten-Digest: %d neue Artikel an %d Empfänger verschickt",
+        len(new_items),
+        len(recipients),
+    )
+    return True

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -21,6 +21,7 @@ import email_service
 email_service.send_verification_email = MagicMock(return_value=None)
 email_service.send_approved_email = MagicMock(return_value=None)
 email_service.send_password_reset_email = MagicMock(return_value=None)
+email_service.send_shopping_list_digest = MagicMock(return_value=None)
 
 from main import app
 from database import Base, get_db

--- a/backend/tests/test_shopping_digest.py
+++ b/backend/tests/test_shopping_digest.py
@@ -1,0 +1,114 @@
+from datetime import datetime, timedelta
+
+import email_service
+import models
+from shopping_digest import run_shopping_digest, WATERMARK_KEY
+
+
+# ---------- Helpers ----------
+
+def _add_item(db, name, added_at, quantity="1", description=None, user=None):
+    item = models.ShoppingItem(
+        name=name,
+        quantity=quantity,
+        description=description,
+        added_by_id=user.id if user else None,
+        added_at=added_at,
+    )
+    db.add(item)
+    db.commit()
+    db.refresh(item)
+    return item
+
+
+def _set_watermark(db, dt):
+    db.add(models.SiteSetting(key=WATERMARK_KEY, value=dt.isoformat()))
+    db.commit()
+
+
+def _watermark(db):
+    s = (
+        db.query(models.SiteSetting)
+        .filter(models.SiteSetting.key == WATERMARK_KEY)
+        .first()
+    )
+    return s.value if s else None
+
+
+# ---------- Erster Lauf (Baseline, kein Versand) ----------
+
+class TestFirstRun:
+    def test_no_items_sets_sentinel_no_mail(self, db_session):
+        email_service.send_shopping_list_digest.reset_mock()
+        assert run_shopping_digest(db_session) is False
+        email_service.send_shopping_list_digest.assert_not_called()
+        # Watermark wurde gesetzt (Sentinel), damit der nächste Artikel als neu gilt
+        assert _watermark(db_session) is not None
+
+    def test_existing_items_baseline_no_mail(self, db_session, household_user):
+        email_service.send_shopping_list_digest.reset_mock()
+        newest = datetime(2026, 1, 1, 12, 0, 0)
+        _add_item(db_session, "Milch", newest - timedelta(hours=1), user=household_user)
+        _add_item(db_session, "Brot", newest, user=household_user)
+
+        assert run_shopping_digest(db_session) is False
+        email_service.send_shopping_list_digest.assert_not_called()
+        # Watermark == neuestes vorhandenes added_at
+        assert _watermark(db_session) == newest.isoformat()
+
+
+# ---------- Versand bei neuen Artikeln ----------
+
+class TestDigestSend:
+    def test_new_item_sends_to_household_and_admin_only(
+        self, db_session, household_user, admin_user, test_user, guest_user
+    ):
+        email_service.send_shopping_list_digest.reset_mock()
+        base = datetime(2026, 1, 1, 12, 0, 0)
+        _set_watermark(db_session, base)
+        _add_item(db_session, "Brot", base + timedelta(minutes=5), user=household_user)
+
+        assert run_shopping_digest(db_session) is True
+        # household + admin = 2 Empfänger; member/guest bekommen nichts
+        assert email_service.send_shopping_list_digest.call_count == 2
+        recipients = {
+            c.args[0] for c in email_service.send_shopping_list_digest.call_args_list
+        }
+        assert recipients == {household_user.email, admin_user.email}
+
+    def test_mail_contains_new_and_full_list(self, db_session, household_user):
+        email_service.send_shopping_list_digest.reset_mock()
+        base = datetime(2026, 1, 1, 12, 0, 0)
+        _add_item(db_session, "Milch", base - timedelta(minutes=10), user=household_user)
+        _set_watermark(db_session, base)
+        _add_item(db_session, "Brot", base + timedelta(minutes=5), user=household_user)
+
+        assert run_shopping_digest(db_session) is True
+        args = email_service.send_shopping_list_digest.call_args.args
+        new_items, all_items = args[2], args[3]
+        assert [i["name"] for i in new_items] == ["Brot"]
+        assert {i["name"] for i in all_items} == {"Milch", "Brot"}
+
+    def test_watermark_advances_and_no_double_send(self, db_session, household_user):
+        email_service.send_shopping_list_digest.reset_mock()
+        base = datetime(2026, 1, 1, 12, 0, 0)
+        _set_watermark(db_session, base)
+        new_at = base + timedelta(minutes=5)
+        _add_item(db_session, "Brot", new_at, user=household_user)
+
+        assert run_shopping_digest(db_session) is True
+        assert _watermark(db_session) == new_at.isoformat()
+
+        # Zweiter Lauf ohne neue Artikel → keine weitere Mail
+        email_service.send_shopping_list_digest.reset_mock()
+        assert run_shopping_digest(db_session) is False
+        email_service.send_shopping_list_digest.assert_not_called()
+
+    def test_no_new_items_no_mail(self, db_session, household_user):
+        email_service.send_shopping_list_digest.reset_mock()
+        base = datetime(2026, 1, 1, 12, 0, 0)
+        _add_item(db_session, "Milch", base - timedelta(minutes=10), user=household_user)
+        _set_watermark(db_session, base)
+
+        assert run_shopping_digest(db_session) is False
+        email_service.send_shopping_list_digest.assert_not_called()


### PR DESCRIPTION
Alle 15 Min prüft das Backend, ob seit der letzten Mail neue Einkaufslisten-Artikel dazugekommen sind. Falls ja → eine Sammel-Mail an alle household-/admin-User mit den neuen Artikeln + der kompletten aktuellen Liste.

- In-Prozess-asyncio-Loop in FastAPI-lifespan, kein neuer Dependency
- State als Highwater-Mark im site_settings-Key `shopping_notify_watermark` → keine Migration
- Erster Lauf setzt Baseline (kein Versand des Altbestands)
- Intervall via `SHOPPING_DIGEST_INTERVAL_SECONDS` (Default 900)

Tests: 312 passed, 3 skipped (bestehende Cascade-Skips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)